### PR TITLE
fix: deduplicate hunt-race-condition, hunt-cache-poison, hunt-subdomain in dispatch WAPT list

### DIFF
--- a/skills/hunt-dispatch/SKILL.md
+++ b/skills/hunt-dispatch/SKILL.md
@@ -100,10 +100,9 @@ hunt-xss             hunt-sqli            hunt-ssrf            hunt-idor
 hunt-csrf            hunt-xxe             hunt-rce             hunt-graphql
 hunt-oauth           hunt-saml            hunt-mfa-bypass      hunt-auth-bypass
 hunt-ato             hunt-file-upload     hunt-business-logic  hunt-race-condition
-hunt-race-condition  hunt-llm-ai          hunt-api-misconfig   hunt-ssti
-hunt-cache-poison hunt-cache-poison    hunt-http-smuggling  hunt-subdomain
-hunt-subdomain  hunt-cloud-misconfig  hunt-misc       hunt-aspnet
-hunt-sharepoint      hunt-ntlm-info
+hunt-llm-ai          hunt-api-misconfig   hunt-ssti            hunt-cache-poison
+hunt-http-smuggling  hunt-subdomain       hunt-cloud-misconfig hunt-misc
+hunt-aspnet          hunt-sharepoint      hunt-ntlm-info
 ```
 
 report format: `report-writing` (`bugcrowd-reporting` if the target is on bugcrowd).


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm-for-claude), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: The WAPT skill list in `skills/hunt-dispatch/SKILL.md` contains three skills listed twice each: `hunt-race-condition`, `hunt-cache-poison`, and `hunt-subdomain` — each appears on two consecutive lines due to a copy-paste overlap.

**Evidence**: Lines 102–106 before fix: `hunt-race-condition` ends line 102 and opens line 103; `hunt-cache-poison` appears twice on line 104; `hunt-subdomain` ends line 104 and opens line 105 — causing each to appear twice when the taxonomy block is emitted to the operator.

**Fix**: Removes the three duplicate occurrences, keeping one entry for each skill in the 4-column layout.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-duplicate-entries","fingerprint":"sha256:4129db9678322a42c92b14901e4da91a9ccd315581968432e8d298d339706718"}]}
nlpm-metadata-end -->