### PR TITLE
fix: remove duplicate skill entries in hunt-dispatch taxonomy

### DIFF
--- a/skills/hunt-dispatch/SKILL.md
+++ b/skills/hunt-dispatch/SKILL.md
@@ -100,9 +100,9 @@ hunt-xss             hunt-sqli            hunt-ssrf            hunt-idor
 hunt-csrf            hunt-xxe             hunt-rce             hunt-graphql
 hunt-oauth           hunt-saml            hunt-mfa-bypass      hunt-auth-bypass
 hunt-ato             hunt-file-upload     hunt-business-logic  hunt-race-condition
-hunt-race-condition  hunt-llm-ai          hunt-api-misconfig   hunt-ssti
-hunt-cache-poison hunt-cache-poison    hunt-http-smuggling  hunt-subdomain
-hunt-subdomain  hunt-cloud-misconfig  hunt-misc       hunt-aspnet
+hunt-llm-ai          hunt-api-misconfig   hunt-ssti
+hunt-cache-poison    hunt-http-smuggling  hunt-subdomain
+hunt-cloud-misconfig  hunt-misc       hunt-aspnet
 hunt-sharepoint      hunt-ntlm-info
 ```
 
@@ -135,9 +135,9 @@ loaded for wapt ({blackbox|greybox}): {N} skills
   authz:      hunt-idor, hunt-auth-bypass, hunt-ato
   auth:       hunt-oauth, hunt-saml, hunt-mfa-bypass
   api:        hunt-graphql, hunt-api-misconfig
-  logic:      hunt-business-logic, hunt-race-condition, hunt-race-condition
-  infra:      hunt-http-smuggling, hunt-cache-poison, hunt-cache-poison
-  recon:      hunt-subdomain, hunt-subdomain
+  logic:      hunt-business-logic, hunt-race-condition
+  infra:      hunt-http-smuggling, hunt-cache-poison
+  recon:      hunt-subdomain
   cloud:      hunt-cloud-misconfig
   ai:         hunt-llm-ai
   stack:      hunt-aspnet, hunt-sharepoint, hunt-ntlm-info


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `skills/hunt-dispatch/SKILL.md` lists three skills twice in both the full hunt-\* set table (lines 102–105) and the WAPT taxonomy block (lines 138–140): `hunt-race-condition`, `hunt-cache-poison`, and `hunt-subdomain` each appear on two consecutive lines, causing each to print twice when the dispatcher emits the session-start taxonomy.

**Evidence**: `grep "hunt-race-condition\|hunt-cache-poison\|hunt-subdomain" skills/hunt-dispatch/SKILL.md` returns two matches each across the table and two matches each in the WAPT category block; the mode=wapt block contains `hunt-race-condition, hunt-race-condition`, `hunt-cache-poison, hunt-cache-poison`, and `hunt-subdomain, hunt-subdomain`.

**Fix**: Removes the second occurrence of each duplicated entry in both the full skill list table and the mode=wapt category lines.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-duplicate-entries","fingerprint":"sha256:4129db9678322a42c92b14901e4da91a9ccd315581968432e8d298d339706718"}]}
nlpm-metadata-end -->