### PR TITLE
CI skill-linter + community infrastructure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default owner for everything — gets auto-requested on every PR.
+* @elementalsouls
+
+# Safety-critical files: changes here should always be maintainer-reviewed.
+/scripts/lint_skills.py            @elementalsouls
+/scripts/.identifier-denylist.sha256 @elementalsouls
+/.github/                          @elementalsouls
+/SECURITY.md                       @elementalsouls

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# GitHub Sponsors / funding links shown on the repo's "Sponsor" button.
+# Sponsor: Atlas Cloud — full-modal AI inference platform (project sponsor).
+github: [elementalsouls]
+custom:
+  - "https://www.atlascloud.ai/console/coding-plan"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: 🐞 Bug / incorrect skill behavior
+description: A skill misfires, fails to trigger, gives wrong guidance, or a script errors.
+title: "[bug] <short summary>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. Please **do not paste real client/engagement data, credentials, or target identifiers** — anonymize everything (see CONTRIBUTING.md).
+  - type: input
+    id: skill
+    attributes:
+      label: Which skill / command?
+      placeholder: "e.g. hunt-ssrf, /hunt, scripts/cbh.py"
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened?
+      description: Include the prompt you used and what Claude did (or didn't do). Redact any sensitive data.
+    validations:
+      required: true
+  - type: dropdown
+    id: trigger
+    attributes:
+      label: Did the skill auto-trigger?
+      options:
+        - "Yes, it loaded but behaved wrong"
+        - "No, it never triggered when it should have"
+        - "It triggered when it should NOT have"
+        - "N/A"
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      placeholder: "Claude Code version, OS, install method (symlink/copy)"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Discussions (questions, ideas, show-and-tell)
+    url: https://github.com/elementalsouls/Claude-BugHunter/discussions
+    about: Ask how to use a skill, request a new one, or share a hunt write-up. Not for bugs.
+  - name: 🔒 Security / responsible disclosure
+    url: https://github.com/elementalsouls/Claude-BugHunter/blob/main/SECURITY.md
+    about: Report a vulnerability in the tooling itself, or a misuse concern. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/false_positive.yml
+++ b/.github/ISSUE_TEMPLATE/false_positive.yml
@@ -1,0 +1,33 @@
+name: 🎯 False-positive / bad guidance report
+description: A skill led to a finding that turned out to be invalid, or gave guidance that breaks the false-positive discipline.
+title: "[fp] <skill> — <what was wrong>"
+labels: ["false-positive"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This project takes false-positive discipline seriously (OOB confirmation, unique markers, body-diff, server-policy-vs-state). Help us tighten the skills. **Anonymize all target data.**
+  - type: input
+    id: skill
+    attributes:
+      label: Which skill produced the bad guidance?
+    validations:
+      required: true
+  - type: textarea
+    id: claim
+    attributes:
+      label: What did the skill claim / suggest?
+    validations:
+      required: true
+  - type: textarea
+    id: reality
+    attributes:
+      label: Why was it actually invalid?
+      description: e.g. reflected value was server policy not attacker-controlled state; no OOB confirmation; response diff was noise.
+    validations:
+      required: true
+  - type: textarea
+    id: fix
+    attributes:
+      label: Suggested guardrail
+      description: What validation step or wording would have prevented it?

--- a/.github/ISSUE_TEMPLATE/new_skill.yml
+++ b/.github/ISSUE_TEMPLATE/new_skill.yml
@@ -1,0 +1,44 @@
+name: ✨ New skill proposal
+description: Propose a new hunt-* or capability skill. Open this BEFORE writing the SKILL.md (per CONTRIBUTING.md).
+title: "[skill] hunt-<name> — <one-line purpose>"
+labels: ["skill-proposal"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Per CONTRIBUTING.md, propose new skills here first so we can confirm scope and avoid overlap before you write the full SKILL.md.
+  - type: input
+    id: name
+    attributes:
+      label: Proposed skill name
+      description: lowercase-hyphen only, e.g. hunt-fintech-graphql
+    validations:
+      required: true
+  - type: textarea
+    id: purpose
+    attributes:
+      label: What gap does it fill?
+      description: What can't be done well with the existing 51 skills? Be specific.
+    validations:
+      required: true
+  - type: textarea
+    id: overlap
+    attributes:
+      label: Overlap check
+      description: Which existing skills are closest, and why is this distinct enough to stand alone?
+    validations:
+      required: true
+  - type: textarea
+    id: sources
+    attributes:
+      label: Source material
+      description: Disclosed reports, CVEs, or research this would be built from (links preferred — the house style cites named reports).
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope confirmation
+      options:
+        - label: This is external-attack-surface focused (not internal AD / C2 / post-exploit — those are deliberately out of scope).
+          required: true
+        - label: It contains no real client/engagement identifiers, credentials, or target-specific exploits — all class-based / anonymized.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!-- Thanks for contributing to claude-bughunter. Keep PRs focused. -->
+
+## What does this change?
+
+<!-- One or two sentences. Link the proposal issue for new skills (#NN). -->
+
+## Type
+
+- [ ] New skill
+- [ ] Improvement to an existing skill
+- [ ] Docs / examples
+- [ ] Tooling / scripts / CI
+- [ ] Other:
+
+## Checklist
+
+- [ ] **No client/engagement data** — no real target names, account UIDs, endpoints, bounty amounts, credentials, or PII. All examples are class-based / anonymized.
+- [ ] `python3 scripts/lint_skills.py` passes locally (frontmatter, name, description length, identifier/secret scan).
+- [ ] For a **new skill**: a proposal issue was opened and agreed first; `name` is lowercase-hyphen; description ≤ 1024 chars and weaves in trigger keywords; body ≤ ~500 lines.
+- [ ] For a new skill: mentioned in `README.md` + `USAGE.md` decision tree, with one worked trigger example.
+- [ ] Sources cited for anything adapted from disclosed reports / community work.
+- [ ] Cross-references complementary skills ("see also …") where there's topical overlap.
+
+## Anything reviewers should know?
+
+<!-- Overlap with existing skills, follow-ups, open questions. -->

--- a/.github/workflows/skill-lint.yml
+++ b/.github/workflows/skill-lint.yml
@@ -1,0 +1,41 @@
+name: skill-lint
+
+# Quality + safety gate for every skill change.
+# - Validates SKILL.md structure against CONTRIBUTING.md rules
+# - Scans for client/engagement identifiers (hashed denylist) and leaked secrets
+# Runs on PRs and pushes to main. No external dependencies — stdlib Python only.
+
+on:
+  pull_request:
+    paths:
+      - "skills/**"
+      - "scripts/lint_skills.py"
+      - "scripts/.identifier-denylist.sha256"
+      - ".github/workflows/skill-lint.yml"
+  push:
+    branches: [main]
+    paths:
+      - "skills/**"
+      - "scripts/lint_skills.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint skills
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate skills (structure + identifier/secret scan)
+        run: python3 scripts/lint_skills.py
+
+      - name: Summary
+        if: always()
+        run: echo "Skill lint finished — see annotations above for any errors/warnings."

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ node_modules/
 
 # Local cbh recon outputs (when run from repo root)
 recon/
+
+# Maintainer-only plaintext client-identifier denylist (never commit names)
+scripts/.identifier-denylist.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to this project are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+versioning is loosely [SemVer](https://semver.org/) at the bundle level.
+
+## [Unreleased]
+
+### Added
+- **CI skill-linter** (`scripts/lint_skills.py` + `.github/workflows/skill-lint.yml`) —
+  validates every `SKILL.md` for frontmatter, `name` format, description length, and
+  body length per `CONTRIBUTING.md`, and scans for leaked secrets and client/engagement
+  identifiers. The identifier denylist is stored as SHA-256 hashes
+  (`scripts/.identifier-denylist.sha256`) so client names never enter the repo in plaintext.
+- **Community infrastructure** — issue templates (bug, new-skill proposal, false-positive),
+  PR template, `CODEOWNERS`, `FUNDING.yml`, `CODE_OF_CONDUCT.md`, and this `CHANGELOG.md`.
+- **Sponsor** — Atlas Cloud added to the README (theme-adaptive logo).
+
+### Changed
+- `.gitignore` now excludes the maintainer-only plaintext denylist override
+  (`scripts/.identifier-denylist.local`).
+
+<!-- When PR #7 (20 new hunt-* skills) merges, move its entry up to the next release. -->
+
+## [2.0] - 2026-05-25
+
+### Added
+- Report-curation pass: 574 → **681 disclosed-report patterns** across 24 vulnerability classes.
+- 5 previously-missing attack surfaces covered; 0 zero-report skills remaining.
+- 29 A-to-B chain examples and `ENGAGEMENTS.md` scaffolding.
+- Enterprise platform attack matrices (M365/Entra, Okta, SharePoint, vCenter, SSL-VPN, APK, supply-chain).
+
+### Changed
+- Top-3 trigger-match concentration rebalanced (81.2% → 68.4%) for better skill routing.
+
+## [1.x]
+
+- Initial public release: 51 skills + 15 slash commands, vendored foundation from
+  `shuvonsec/claude-bug-bounty`, Burp MCP integration, recon pipeline.
+
+[Unreleased]: https://github.com/elementalsouls/Claude-BugHunter/compare/v2.0...HEAD
+[2.0]: https://github.com/elementalsouls/Claude-BugHunter/releases/tag/v2.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -45,10 +45,13 @@ This project ships offensive-security tradecraft. In addition to the above:
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior — or misuse of
-the community as described above — may be reported to the maintainer at
-**sachin.lucideus@gmail.com**. All complaints will be reviewed and investigated
-promptly and fairly. The maintainer is obligated to respect the privacy and
-security of the reporter.
+the community as described above — may be reported **privately** to the maintainer
+via the repository's **Security tab → "Report a vulnerability"**
+([GitHub private reporting](https://github.com/elementalsouls/Claude-BugHunter/security/advisories/new)),
+or by contacting the maintainer through their GitHub profile
+([@elementalsouls](https://github.com/elementalsouls)). All complaints will be
+reviewed and investigated promptly and fairly. The maintainer is obligated to
+respect the privacy and security of the reporter.
 
 Maintainers who do not follow or enforce this Code of Conduct in good faith may
 face temporary or permanent repercussions as determined by the project's leadership.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,63 @@
+# Code of Conduct
+
+## Our pledge
+
+We — contributors and maintainers — pledge to make participation in this project
+a harassment-free experience for everyone, regardless of age, body size, visible
+or invisible disability, ethnicity, sex characteristics, gender identity and
+expression, level of experience, education, socio-economic status, nationality,
+personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback on skills and PRs
+- Accepting responsibility, apologizing to those affected by our mistakes, and
+  learning from the experience
+- Focusing on what is best for the community and the people who rely on this tooling
+
+Examples of unacceptable behavior:
+
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Sexualized language or imagery, or unwelcome sexual attention
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Security-tooling responsible-use clause
+
+This project ships offensive-security tradecraft. In addition to the above:
+
+- **Do not** use issues, discussions, or PRs to solicit, coordinate, or brag about
+  testing against systems you are not authorized to assess. See `SECURITY.md` for
+  the authorized-use posture.
+- **Do not** post real client/engagement identifiers, credentials, victim PII, or
+  target-specific exploit details. Anonymize everything (see `CONTRIBUTING.md`).
+- Discussion of techniques is welcome; using this community to facilitate
+  unauthorized access or harm is not, and is grounds for an immediate ban.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior — or misuse of
+the community as described above — may be reported to the maintainer at
+**sachin.lucideus@gmail.com**. All complaints will be reviewed and investigated
+promptly and fairly. The maintainer is obligated to respect the privacy and
+security of the reporter.
+
+Maintainers who do not follow or enforce this Code of Conduct in good faith may
+face temporary or permanent repercussions as determined by the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>,
+with an added responsible-use clause specific to offensive-security tooling.
+
+[homepage]: https://www.contributor-covenant.org

--- a/scripts/.identifier-denylist.sha256
+++ b/scripts/.identifier-denylist.sha256
@@ -1,0 +1,22 @@
+# Client-identifier denylist — SHA-256 hashes, NOT plaintext.
+#
+# Why hashes? The whole point of this gate is to keep real client/engagement
+# identifiers OUT of the public repo. Committing the names in plaintext (even in
+# a denylist) would itself leak them. So we store SHA-256 of each normalized
+# identifier instead. The linter (scripts/lint_skills.py) normalizes every
+# 1- and 2-word shingle of each SKILL.md the same way and compares hashes.
+#
+# Normalization: lowercase, collapse internal whitespace to single spaces.
+#
+# To add a NEW identifier without leaking it, either:
+#   (a) add its SHA-256 here:  printf '%s' "the name" | tr '[:upper:]' '[:lower:]' | shasum -a 256
+#   (b) drop it in scripts/.identifier-denylist.local (one per line, gitignored) —
+#       the linter hashes that file at runtime so you never commit the plaintext.
+#
+# One hash per line. Blank lines and #-comments ignored.
+a672b3be0c15a2af015886aef804d485704c37a56cfa8a564c973ccd944a2ee1
+6d99af9a927fd75a379a2d085c772acd6fb4a81cd7a3c75aaffa7529536d0e1a
+3b39f05d6785c7b4ac3e3e08dfc2abbc07bdde4a01c58fdf944d326afd4af3ab
+80537d65d479a2f986a78e859cc2bcaaf6a62f6df7a6ba2c5dd192cfcb2ff790
+ae95921ebc9d9f3e72d883f217ff023fc5555d111ca0bf3b18c5b8cd0c5d7580
+e7dcc519de2734ed30de133910fd3289c9afc89aef272f7239d17fac804b24a0

--- a/scripts/lint_skills.py
+++ b/scripts/lint_skills.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+lint_skills.py — quality + safety gate for claude-bughunter skills.
+
+Enforces the rules documented in CONTRIBUTING.md and the repo's hard rule that
+NO real client/engagement identifiers ever land in the public tree.
+
+Checks per skills/<name>/SKILL.md:
+  STRUCTURE (errors)
+    - frontmatter block present (between the first two `---` lines)
+    - `name` present, matches ^[a-z0-9-]+$, and equals the directory name
+    - `description` present and <= 1024 chars
+    - body (everything after frontmatter) <= 500 lines
+  SAFETY (errors)
+    - client-identifier denylist: hashes every 1- and 2-word shingle of the file
+      and compares against scripts/.identifier-denylist.sha256 (+ optional
+      .identifier-denylist.local). Plaintext names never live in the repo.
+    - real-secret scan: AWS keys, private-key blocks, JWTs, Slack/Google tokens.
+      Documentation patterns (regexes, AWS EXAMPLE tokens) are allowlisted so the
+      secret-catalog skills don't trip it.
+
+Exit code 0 = clean, 1 = at least one error. Warnings never fail the build.
+Stdlib only — no pip install needed in CI.
+
+Usage:
+    python3 scripts/lint_skills.py                 # lint all skills
+    python3 scripts/lint_skills.py skills/hunt-xss  # lint specific dirs
+"""
+import hashlib
+import os
+import re
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SKILLS_DIR = os.path.join(REPO, "skills")
+SCRIPTS_DIR = os.path.join(REPO, "scripts")
+
+NAME_RE = re.compile(r"^[a-z0-9-]+$")
+MAX_DESC = 1024
+MAX_BODY_LINES = 500
+
+# --- real-secret patterns (kept tight to avoid flagging documented regexes) ---
+SECRET_PATTERNS = [
+    ("AWS access key", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
+    ("Private key block", re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----")),
+    ("JWT", re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b")),
+    ("Slack token", re.compile(r"\bxox[baprs]-[0-9A-Za-z-]{10,}\b")),
+    ("Google API key", re.compile(r"\bAIza[0-9A-Za-z_-]{35}\b")),
+    ("GitHub PAT", re.compile(r"\bghp_[0-9A-Za-z]{36}\b")),
+]
+# Tokens that are public documentation/examples, not real secrets.
+# `\.\.\.` covers placeholder blocks like "-----BEGIN PRIVATE KEY-----..." in docs.
+SECRET_ALLOW = re.compile(
+    r"AKIAIOSFODNN7EXAMPLE|EXAMPLE|wJalrXUtnFEMI|\[0-9A-Z\]|\{1[06]\}|<[^>]+>|\.\.\."
+)
+
+# Intentional kitchen-sink router/aggregator skills whose descriptions deliberately
+# exceed the per-skill limit (they route to everything). Over-length is a warning,
+# not an error, for these. Do NOT add new skills here — write focused descriptions.
+DESC_LIMIT_GRANDFATHERED = {"bug-bounty", "bb-local-toolkit", "osint-methodology"}
+
+WORD_RE = re.compile(r"[a-z0-9]+")
+
+
+def load_denylist():
+    """Return a set of sha256 hex digests of banned identifiers."""
+    hashes = set()
+    sha_file = os.path.join(SCRIPTS_DIR, ".identifier-denylist.sha256")
+    if os.path.exists(sha_file):
+        with open(sha_file, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    hashes.add(line.lower())
+    # Optional gitignored plaintext override for maintainer convenience.
+    local = os.path.join(SCRIPTS_DIR, ".identifier-denylist.local")
+    if os.path.exists(local):
+        with open(local, encoding="utf-8") as fh:
+            for line in fh:
+                name = " ".join(line.strip().lower().split())
+                if name and not name.startswith("#"):
+                    hashes.add(hashlib.sha256(name.encode()).hexdigest())
+    return hashes
+
+
+def shingles(text):
+    """Yield normalized 1- and 2-word shingles from text."""
+    words = WORD_RE.findall(text.lower())
+    for i, w in enumerate(words):
+        yield w
+        if i + 1 < len(words):
+            yield w + " " + words[i + 1]
+
+
+def split_frontmatter(raw):
+    """Return (frontmatter_dict, body_text, error_or_None)."""
+    if not raw.startswith("---"):
+        return {}, raw, "no frontmatter block (file must start with '---')"
+    parts = raw.split("\n")
+    # find closing --- after line 0
+    close = None
+    for i in range(1, len(parts)):
+        if parts[i].strip() == "---":
+            close = i
+            break
+    if close is None:
+        return {}, raw, "frontmatter opened with '---' but never closed"
+    fm = {}
+    for line in parts[1:close]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        m = re.match(r"^([A-Za-z0-9_-]+):\s*(.*)$", line)
+        if m:
+            fm[m.group(1)] = m.group(2).strip()
+    body = "\n".join(parts[close + 1:])
+    return fm, body, None
+
+
+def lint_skill(skill_dir, denylist):
+    errors, warnings = [], []
+    name = os.path.basename(skill_dir.rstrip("/"))
+    path = os.path.join(skill_dir, "SKILL.md")
+    if not os.path.isfile(path):
+        return [f"{name}: missing SKILL.md"], []
+    with open(path, encoding="utf-8") as fh:
+        raw = fh.read()
+
+    fm, body, fm_err = split_frontmatter(raw)
+    if fm_err:
+        errors.append(f"{name}: {fm_err}")
+    # name
+    fn = fm.get("name", "")
+    if not fn:
+        errors.append(f"{name}: frontmatter missing `name`")
+    else:
+        if not NAME_RE.match(fn):
+            errors.append(f"{name}: `name` '{fn}' must match ^[a-z0-9-]+$")
+        if fn != name:
+            errors.append(f"{name}: `name` '{fn}' != directory '{name}'")
+    # description
+    desc = fm.get("description", "")
+    if not desc:
+        errors.append(f"{name}: frontmatter missing `description`")
+    elif len(desc) > MAX_DESC:
+        msg = f"{name}: description {len(desc)} chars > {MAX_DESC} limit"
+        (warnings if name in DESC_LIMIT_GRANDFATHERED else errors).append(msg)
+    elif len(desc) < 40:
+        warnings.append(f"{name}: description very short ({len(desc)} chars) — weak trigger surface")
+    # body length
+    body_lines = len(body.splitlines())
+    if body_lines > MAX_BODY_LINES:
+        warnings.append(f"{name}: body {body_lines} lines > {MAX_BODY_LINES} guideline (use references/ subfolder)")
+
+    # client-identifier denylist
+    if denylist:
+        hit = set()
+        for sh in shingles(raw):
+            if hashlib.sha256(sh.encode()).hexdigest() in denylist:
+                hit.add(sh)
+        if hit:
+            errors.append(
+                f"{name}: CLIENT-IDENTIFIER MATCH — {len(hit)} banned shingle(s). "
+                f"Remove client/engagement identifiers before committing."
+            )
+
+    # real-secret scan
+    for lineno, line in enumerate(raw.splitlines(), 1):
+        for label, pat in SECRET_PATTERNS:
+            for m in pat.finditer(line):
+                snippet = m.group(0)
+                window = line[max(0, m.start() - 8): m.end() + 8]
+                if SECRET_ALLOW.search(window) or SECRET_ALLOW.search(snippet):
+                    continue
+                errors.append(f"{name}:{lineno}: possible {label} leaked — '{snippet[:24]}...'")
+    return errors, warnings
+
+
+def main(argv):
+    denylist = load_denylist()
+    if argv:
+        targets = [a if os.path.isabs(a) else os.path.join(REPO, a) for a in argv]
+    else:
+        targets = [os.path.join(SKILLS_DIR, d) for d in sorted(os.listdir(SKILLS_DIR))
+                   if os.path.isdir(os.path.join(SKILLS_DIR, d))]
+
+    all_errors, all_warnings = [], []
+    for t in targets:
+        e, w = lint_skill(t, denylist)
+        all_errors += e
+        all_warnings += w
+
+    for w in all_warnings:
+        print(f"::warning:: {w}" if os.environ.get("GITHUB_ACTIONS") else f"WARN  {w}")
+    for e in all_errors:
+        print(f"::error:: {e}" if os.environ.get("GITHUB_ACTIONS") else f"ERROR {e}")
+
+    n = len(targets)
+    print(f"\nLinted {n} skill(s): {len(all_errors)} error(s), {len(all_warnings)} warning(s).")
+    if not denylist:
+        print("NOTE: no client-identifier denylist loaded (scripts/.identifier-denylist.sha256 missing).")
+    return 1 if all_errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Makes the project safe to scale to community contributions — the keystone for accepting larger PRs (like #7) without manually auditing every line.

## What's in here

**CI skill-linter** (the gate)
- `scripts/lint_skills.py` — validates every `SKILL.md` against the rules already documented in `CONTRIBUTING.md`: frontmatter present, `name` is lowercase-hyphen and matches its directory, `description` ≤ 1024 chars, body ≤ 500 lines.
- **Client-identifier scan** — hashes every 1- and 2-word shingle of each file and compares against `scripts/.identifier-denylist.sha256`. The denylist stores **SHA-256 hashes, never plaintext**, so engagement/client names can't leak into the repo (the very thing it's preventing). Maintainers can add names via a gitignored `.identifier-denylist.local` override.
- **Secret scan** — AWS keys, private-key blocks, JWTs, Slack/Google/GitHub tokens; documented regex patterns and `EXAMPLE` tokens are allowlisted so the secret-catalog skills don't false-positive.
- `.github/workflows/skill-lint.yml` runs it on every PR touching `skills/`. Stdlib-only, no deps.
- **Passes clean on all 51 existing skills** (0 errors). Grandfathers the 3 aggregator-skill descriptions that intentionally exceed the length limit. Negative-tested: catches planted client names + JWTs.

**Community infrastructure**
- Issue templates: bug report, new-skill proposal (enforces "open an issue first"), false-positive report (ties to the FP discipline).
- PR template with a no-client-data + run-the-linter checklist.
- `CODEOWNERS`, `FUNDING.yml` (Atlas Cloud sponsor + GitHub Sponsors).
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1 + an offensive-security responsible-use clause.
- `CHANGELOG.md` — Keep a Changelog format, backfills v2.0.

## Follow-ups (not in this PR)
- Enable GitHub Discussions, set repo homepage.
- Merge PR #7 (20 new skills) — this linter will validate it.
- Cut v2.1 once #7 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)