### PR TITLE
fix: path traversal, shell injection, Q5 logic, TLS bypass (closes #13)

### DIFF
--- a/scripts/cbh.py
+++ b/scripts/cbh.py
@@ -105,7 +105,11 @@ def configure_http_proxy(proxy_url: str | None = None) -> tuple[bool, str]:
     import ssl
     ctx = ssl.create_default_context()
     ctx.check_hostname = False
+    # WARNING: TLS verification is disabled for Burp proxy traffic.
+    # Use --proxy only in isolated lab environments — not on production targets.
     ctx.verify_mode = ssl.CERT_NONE
+    print("[warning] TLS certificate verification is DISABLED — proxy mode active. "
+          "Use only in isolated lab environments, not on production targets.", flush=True)
 
     proxy_handler = urllib.request.ProxyHandler({"http": proxy_url, "https": proxy_url})
     https_handler = urllib.request.HTTPSHandler(context=ctx)
@@ -229,6 +233,11 @@ def configure_proxy_from_args(args: argparse.Namespace) -> None:
 def cmd_recon(args: argparse.Namespace) -> int:
     target = args.target
     out_dir = REPO_ROOT / "recon" / target
+    resolved = out_dir.resolve()
+    safe = (REPO_ROOT / "recon").resolve()
+    if not str(resolved).startswith(str(safe)):
+        print(f"[error] invalid target: {target}", file=sys.stderr); return 1
+    out_dir = resolved
     out_dir.mkdir(parents=True, exist_ok=True)
 
     section(f"recon — {target}")
@@ -469,7 +478,7 @@ TRIAGE_QUESTIONS = [
     ("Q4", "Does it work without privileged access an attacker can't get?",
      ["attacker", "unauthenticated", "user-role", "low-priv", "any user", "session"]),
     ("Q5", "Is this not already known or documented behavior?",
-     ["disclosed-reports", "h1 hacktivity", "duplicate", "not duplicate", "novel", "previously"]),
+     ["disclosed-reports", "h1 hacktivity", "not duplicate", "novel", "first reported", "previously unknown", "previously"]),
     ("Q6", "Can impact be proved beyond 'technically possible'?",
      ["leaked", "exfiltrated", "rce", "data:", "credential", "session-id", "cookie:",
       "admin email", "production", "oob callback", "interactsh"]),
@@ -667,6 +676,9 @@ def cmd_report(args: argparse.Namespace) -> int:
     draft = render_report(md, args.platform)
     if args.out:
         out_path = Path(args.out)
+        out_path = out_path.resolve()
+        if not str(out_path).startswith(str(Path.cwd().resolve())):
+            print("[error] --out path must be within cwd", file=sys.stderr); return 1
         out_path.write_text(draft)
         section(f"report — {args.platform}")
         say(f"  Draft written: {color(str(out_path), 'bold')}")

--- a/scripts/hunt.sh
+++ b/scripts/hunt.sh
@@ -38,11 +38,12 @@ hunt() {
   mkdir -p "$dir/findings" "$dir/evidence"
 
   # ============== CLAUDE.md ==============
-  cat > "$dir/CLAUDE.md" <<CLAUDEMD
-# Engagement: $target
-
-**Target:** $target
-**Started:** $(date -u +"%Y-%m-%d")
+  # Write heading lines that require $target interpolation explicitly,
+  # then append the static body via a quoted heredoc (no shell injection risk).
+  printf '# Engagement: %s\n\n' "$target" > "$dir/CLAUDE.md"
+  printf '**Target:** %s\n' "$target" >> "$dir/CLAUDE.md"
+  printf '**Started:** %s\n' "$(date -u +"%Y-%m-%d")" >> "$dir/CLAUDE.md"
+  cat >> "$dir/CLAUDE.md" <<'CLAUDEMD'
 **Platform:** [TBD — Bugcrowd / HackerOne / Intigriti / Immunefi / private]
 **Program URL:** [paste the program page URL here]
 
@@ -98,8 +99,8 @@ Files in this folder:
 CLAUDEMD
 
   # ============== scope.md ==============
-  cat > "$dir/scope.md" <<SCOPEMD
-# Scope — $target
+  printf '# Scope — %s\n' "$target" > "$dir/scope.md"
+  cat >> "$dir/scope.md" <<'SCOPEMD'
 
 > Parse this from the program page (Bugcrowd / HackerOne / etc.) before
 > doing any active testing. \`/scope <asset>\` can verify individual assets.
@@ -151,8 +152,8 @@ CLAUDEMD
 SCOPEMD
 
   # ============== submissions.txt ==============
-  cat > "$dir/submissions.txt" <<SUBSEOF
-# Submissions tracker — $target
+  printf '# Submissions tracker — %s\n' "$target" > "$dir/submissions.txt"
+  cat >> "$dir/submissions.txt" <<'SUBSEOF'
 #
 # Format (tab-separated):
 # <UUID>  <severity>  <VRT-or-class>  <one-line title>
@@ -163,8 +164,8 @@ SCOPEMD
 SUBSEOF
 
   # ============== findings/README.md ==============
-  cat > "$dir/findings/README.md" <<FINDREADME
-# Findings — $target
+  printf '# Findings — %s\n' "$target" > "$dir/findings/README.md"
+  cat >> "$dir/findings/README.md" <<'FINDREADME'
 
 One markdown file per lead.
 
@@ -190,8 +191,8 @@ Each finding file should have:
 FINDREADME
 
   # ============== notes.md ==============
-  cat > "$dir/notes.md" <<NOTESMD
-# Notes — $target
+  printf '# Notes — %s\n' "$target" > "$dir/notes.md"
+  cat >> "$dir/notes.md" <<'NOTESMD'
 
 > Running scratchpad. Leads, hypotheses, dead ends.
 
@@ -209,7 +210,7 @@ FINDREADME
 NOTESMD
 
   # ============== .gitignore ==============
-  cat > "$dir/.gitignore" <<GITIGNORE
+  cat > "$dir/.gitignore" <<'GITIGNORE'
 # Never commit raw evidence — contains live cookies, PII, HARs
 evidence/
 


### PR DESCRIPTION
Fixes #13

This PR was generated by [Conduct AI](https://conductai.ai)'s `security-autopilot-fix` playbook.
The full run trace — Guard checks, agentic brain turns, Slack notification — is captured in the Conduct dashboard.

## Changes

**scripts/cbh.py**
- Fix path traversal in `cmd_recon`: validate `out_dir` stays under `REPO_ROOT/recon/`
- Fix arbitrary file write via `--out` flag: restrict output path to CWD
- Fix Q5 triage logic: remove `"duplicate"` from novelty signals so confirmed duplicates fail the gate
- Fix TLS bypass: add prominent warning + `print()` when `ssl.CERT_NONE` is active via `--proxy`

**scripts/hunt.sh**
- Fix shell injection: quote heredoc delimiters (`<<'CLAUDEMD'` etc.) and move `$target` interpolation to explicit `printf` statements

---
*Generated by Conduct AI · security-autopilot-fix playbook · issue #13*