### PR TITLE
Salvage unique content from deprecated installed skill stubs

### DIFF
--- a/skills/hunt-auth-bypass/SKILL.md
+++ b/skills/hunt-auth-bypass/SKILL.md
@@ -407,6 +407,36 @@ Cross-references for the chain:
 
 ---
 
+## Function-Level Access Control (Broken Authorization)
+
+Authentication bypass gets you *in*; **function-level access control** failures let an already-authenticated low-privilege user reach privileged *functions* the UI never offered them. This is the authorization sibling of `hunt-idor` (object-level access) — test both whenever you hold any authenticated session.
+
+**The sibling-function rule:** if 9 endpoints under a path enforce auth/role middleware, the 10th that doesn't is your bug. Admin route families are the highest-yield place to look:
+
+```
+/api/admin/users   → has auth middleware
+/api/admin/export  → often MISSING it
+/api/admin/delete  → often MISSING it
+/api/admin/reset   → often MISSING it
+```
+
+**Anti-patterns to grep for:**
+```javascript
+// Missing middleware on a sibling route
+router.get('/admin/users',  authenticate, authorize('admin'), getUsers);
+router.get('/admin/export', getExport);            // No middleware!
+
+// Client-side role check only — server never re-checks
+if (user.role === 'admin') showAdminButton();      // frontend gate
+app.post('/api/admin/delete', deleteUser);         // no server-side check
+```
+
+**How to hunt:** enumerate every privileged endpoint (admin/export/delete/reset/impersonate, GraphQL admin queries), then replay each from a *regular* authenticated session — and again with no session. A 200 (or a differential vs the 403 its siblings return) is broken function-level access control.
+
+**Real paid example — HackerOne TrustHub:** `POST /graphql` with the `TrustHubQuery` operation had no authorization check — a regular user could read all vendors' data (CVSS 8.7, High). The object-level variant (e.g. a WebSocket `get_history` accepting an arbitrary UUID with no ownership check) belongs to `hunt-idor`.
+
+---
+
 ## Related Skills & Chains
 
 - **`hunt-idor`** — Auth bypass without object-level access is half a finding; pair them. Chain primitive: legacy `/v1/users/{id}` route missing both auth middleware AND ownership check = unauthenticated cross-tenant data read via direct ID substitution → full PII dump from "I am nobody" starting position.

--- a/skills/hunt-subdomain/SKILL.md
+++ b/skills/hunt-subdomain/SKILL.md
@@ -41,6 +41,7 @@ Subdomain takeover is high-value because it allows an attacker to serve content 
 - `"Do you want to register"` (any domain parking page)
 - HTTP 404 with provider-specific error templates
 - Fastly: `"Fastly error: unknown domain"`
+- `"404 Web Site not found"` (Azure App Service)
 
 **Tech stack signals:**
 - Response headers: `X-Served-By: cache-*` (Fastly), `X-GitHub-Request-Id`, `Server: Netlify`


### PR DESCRIPTION
Before deleting any of the stale skill dirs sitting in a local `~/.claude/skills/` install, I diffed all 5 against their canonical repo replacements to make sure nothing unique was lost. Result: **3 fully subsumed, 2 had one salvageable item each** — merged here.

## Audit result

| Installed-only dir | vs canonical | Verdict |
|---|---|---|
| `hunt-cache-poisoning` (39 ln) | `hunt-cache-poison` (294) | Fully subsumed — nothing unique |
| `hunt-race` (40 ln) | `hunt-race-condition` (461) | Fully subsumed — nothing unique |
| `offensive-osint.backup-20260504` | `offensive-osint` | Current is a superset (14/15 ref files byte-identical) |
| `hunt-subdomain-takeover` (36 ln) | `hunt-subdomain` (334) | **1 item salvaged** ↓ |
| `web2-vuln-classes.disabled` (832 ln, 18 classes) | per-class `hunt-*` + `bug-bounty` | 19/20 covered; **1 item salvaged** ↓ |

## What this PR adds

- **`hunt-subdomain`** — the Azure App Service takeover fingerprint `"404 Web Site not found"`, the only signal the old takeover stub had that the canonical skill lacked.
- **`hunt-auth-bypass`** — a new **Function-Level Access Control (Broken Authorization)** section: the sibling-function rule, the missing-middleware / client-side-role-check anti-patterns, and the HackerOne TrustHub paid example. The disabled `web2-vuln-classes` monolith covered this; the per-class skills didn't (auth-bypass covered *authentication*, not function-level *authorization*).

+31 lines across 2 files. Bodies of all other skills untouched.

## Follow-up
After this merges, the 5 installed dirs are content-complete in the repo and safe to delete from your local `~/.claude/skills/`. Deletion is left to you (you asked to decide that separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)