### PR TITLE
Security fixes for #13 (path traversal, shell injection, Q5, TLS) — hardened

### DIFF
--- a/scripts/cbh.py
+++ b/scripts/cbh.py
@@ -105,7 +105,11 @@ def configure_http_proxy(proxy_url: str | None = None) -> tuple[bool, str]:
     import ssl
     ctx = ssl.create_default_context()
     ctx.check_hostname = False
+    # WARNING: TLS verification is disabled for Burp proxy traffic.
+    # Use --proxy only in isolated lab environments — not on production targets.
     ctx.verify_mode = ssl.CERT_NONE
+    print("[warning] TLS certificate verification is DISABLED — proxy mode active. "
+          "Use only in isolated lab environments, not on production targets.", flush=True)
 
     proxy_handler = urllib.request.ProxyHandler({"http": proxy_url, "https": proxy_url})
     https_handler = urllib.request.HTTPSHandler(context=ctx)
@@ -229,6 +233,11 @@ def configure_proxy_from_args(args: argparse.Namespace) -> None:
 def cmd_recon(args: argparse.Namespace) -> int:
     target = args.target
     out_dir = REPO_ROOT / "recon" / target
+    resolved = out_dir.resolve()
+    safe = (REPO_ROOT / "recon").resolve()
+    if not str(resolved).startswith(str(safe)):
+        print(f"[error] invalid target: {target}", file=sys.stderr); return 1
+    out_dir = resolved
     out_dir.mkdir(parents=True, exist_ok=True)
 
     section(f"recon — {target}")
@@ -469,7 +478,7 @@ TRIAGE_QUESTIONS = [
     ("Q4", "Does it work without privileged access an attacker can't get?",
      ["attacker", "unauthenticated", "user-role", "low-priv", "any user", "session"]),
     ("Q5", "Is this not already known or documented behavior?",
-     ["disclosed-reports", "h1 hacktivity", "duplicate", "not duplicate", "novel", "previously"]),
+     ["disclosed-reports", "h1 hacktivity", "not duplicate", "novel", "first reported", "previously unknown", "previously"]),
     ("Q6", "Can impact be proved beyond 'technically possible'?",
      ["leaked", "exfiltrated", "rce", "data:", "credential", "session-id", "cookie:",
       "admin email", "production", "oob callback", "interactsh"]),
@@ -667,6 +676,9 @@ def cmd_report(args: argparse.Namespace) -> int:
     draft = render_report(md, args.platform)
     if args.out:
         out_path = Path(args.out)
+        out_path = out_path.resolve()
+        if not str(out_path).startswith(str(Path.cwd().resolve())):
+            print("[error] --out path must be within cwd", file=sys.stderr); return 1
         out_path.write_text(draft)
         section(f"report — {args.platform}")
         say(f"  Draft written: {color(str(out_path), 'bold')}")

--- a/scripts/cbh.py
+++ b/scripts/cbh.py
@@ -235,7 +235,9 @@ def cmd_recon(args: argparse.Namespace) -> int:
     out_dir = REPO_ROOT / "recon" / target
     resolved = out_dir.resolve()
     safe = (REPO_ROOT / "recon").resolve()
-    if not str(resolved).startswith(str(safe)):
+    # Real containment check — `startswith` is bypassable by a sibling that
+    # shares the prefix (e.g. recon-evil vs recon), so test ancestry properly.
+    if resolved != safe and safe not in resolved.parents:
         print(f"[error] invalid target: {target}", file=sys.stderr); return 1
     out_dir = resolved
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -675,9 +677,10 @@ def cmd_report(args: argparse.Namespace) -> int:
     md = parse_finding_metadata(finding_path.read_text(encoding="utf-8"))
     draft = render_report(md, args.platform)
     if args.out:
-        out_path = Path(args.out)
-        out_path = out_path.resolve()
-        if not str(out_path).startswith(str(Path.cwd().resolve())):
+        out_path = Path(args.out).resolve()
+        cwd = Path.cwd().resolve()
+        # Ancestry check, not str.startswith (which a `<cwd>-evil` sibling bypasses).
+        if cwd not in out_path.parents:
             print("[error] --out path must be within cwd", file=sys.stderr); return 1
         out_path.write_text(draft)
         section(f"report — {args.platform}")

--- a/scripts/hunt.sh
+++ b/scripts/hunt.sh
@@ -52,33 +52,33 @@ hunt() {
 This folder is the working directory for a single bug-bounty engagement.
 Files in this folder:
 
-- \`scope.md\` — parsed scope, OOS list, focus areas, bounty bands
-- \`findings/\` — one markdown file per finding draft (naming: \`finding-<NN>-<short-name>.md\`)
-- \`submissions.txt\` — submission IDs tracker (used for chain cross-references)
-- \`evidence/\` — screenshots, HARs, raw transcripts (gitignored — never share)
-- \`notes.md\` — running notes, leads, dead ends, hypotheses
+- `scope.md` — parsed scope, OOS list, focus areas, bounty bands
+- `findings/` — one markdown file per finding draft (naming: `finding-<NN>-<short-name>.md`)
+- `submissions.txt` — submission IDs tracker (used for chain cross-references)
+- `evidence/` — screenshots, HARs, raw transcripts (gitignored — never share)
+- `notes.md` — running notes, leads, dead ends, hypotheses
 
 ## Workflow
 
-1. **Plan** — fill in \`scope.md\` from the program page. Use the \`bb-methodology\`
-   and \`osint-methodology\` skills. Note Focus Areas and Bounty bands.
+1. **Plan** — fill in `scope.md` from the program page. Use the `bb-methodology`
+   and `osint-methodology` skills. Note Focus Areas and Bounty bands.
 
-2. **Recon** — \`offensive-osint\`, \`web2-recon\`, and \`bb-local-toolkit\` for
+2. **Recon** — `offensive-osint`, `web2-recon`, and `bb-local-toolkit` for
    discovery. Pipe Burp through every browser session for proxy history.
 
-3. **Hunt** — \`web2-vuln-classes\` (or per-class \`hunt-*\` skills if installed)
-   plus \`security-arsenal\` for payloads.
+3. **Hunt** — `web2-vuln-classes` (or per-class `hunt-*` skills if installed)
+   plus `security-arsenal` for payloads.
 
-4. **Validate** — run \`/triage\` on every lead BEFORE drafting a report.
-   Apply the 7-Question Gate from \`triage-validation\`.
+4. **Validate** — run `/triage` on every lead BEFORE drafting a report.
+   Apply the 7-Question Gate from `triage-validation`.
 
-5. **Capture evidence** — \`evidence-hygiene\` BEFORE any screenshot.
+5. **Capture evidence** — `evidence-hygiene` BEFORE any screenshot.
    Cookies / PII / HARs all redacted per protocol.
 
-6. **Report** — \`report-writing\` for the body template. \`bugcrowd-reporting\`
+6. **Report** — `report-writing` for the body template. `bugcrowd-reporting`
    if filing on Bugcrowd (VRT search, severity request, OOS rebuttals).
 
-7. **Track** — append every submitted finding's UUID to \`submissions.txt\`
+7. **Track** — append every submitted finding's UUID to `submissions.txt`
    so chained reports can cross-reference each other.
 
 ## Engagement-specific rules
@@ -86,16 +86,16 @@ Files in this folder:
 - All testing on accounts I own.
 - Stop immediately on encountering other-user PII; document and report.
 - No public disclosure until program explicitly approves.
-- Test-account email: \`<your-bugcrowdninja-alias>@bugcrowdninja.com\`
+- Test-account email: `<your-bugcrowdninja-alias>@bugcrowdninja.com`
 - Burp proxy capturing through all browser sessions for this target.
 
 ## Useful commands during the engagement
 
-- \`/scope <asset>\` — verify a specific asset is in scope
-- \`/triage\` — quick 7-Question Gate on a finding
-- \`/validate\` — full 4-gate finding validator
-- \`/report\` — draft a submission-ready report
-- \`/remember\` — log a finding to hunt memory
+- `/scope <asset>` — verify a specific asset is in scope
+- `/triage` — quick 7-Question Gate on a finding
+- `/validate` — full 4-gate finding validator
+- `/report` — draft a submission-ready report
+- `/remember` — log a finding to hunt memory
 CLAUDEMD
 
   # ============== scope.md ==============
@@ -103,7 +103,7 @@ CLAUDEMD
   cat >> "$dir/scope.md" <<'SCOPEMD'
 
 > Parse this from the program page (Bugcrowd / HackerOne / etc.) before
-> doing any active testing. \`/scope <asset>\` can verify individual assets.
+> doing any active testing. `/scope <asset>` can verify individual assets.
 
 ## In scope
 
@@ -134,7 +134,7 @@ CLAUDEMD
 
 ## Account / testing setup
 
-- **Test account email:** (\`alias@bugcrowdninja.com\` if Bugcrowd)
+- **Test account email:** (`alias@bugcrowdninja.com` if Bugcrowd)
 - **Test account uid:**
 - **Production vs QA:** (which environment is in scope, and any special access notes)
 - **Mobile builds:** (Android APK / iOS IPA download URLs if provided)
@@ -143,7 +143,7 @@ CLAUDEMD
 ## OOS clauses worth pre-empting in submissions
 
 > Note any OOS clauses that might be miscategorized against your findings.
-> Use this to draft \`In-scope justification\` paragraphs proactively.
+> Use this to draft `In-scope justification` paragraphs proactively.
 
 - (e.g., "Rate limiting on non-authentication endpoints" — applies to
   non-auth endpoints only; verify_password / OTP / token-validate are auth)
@@ -158,7 +158,7 @@ SCOPEMD
 # Format (tab-separated):
 # <UUID>  <severity>  <VRT-or-class>  <one-line title>
 #
-# Use \`/remember\` after each submission to append the new ID and link
+# Use `/remember` after each submission to append the new ID and link
 # back to chained primitives.
 
 SUBSEOF
@@ -171,18 +171,18 @@ One markdown file per lead.
 
 ## Naming
 
-\`finding-<NN>-<short-name>.md\`
+`finding-<NN>-<short-name>.md`
 
 Examples:
-- \`finding-01-graphql-apq-bypass.md\`
-- \`finding-02-verify-password-no-rate-limit.md\`
-- \`finding-03-update-password-no-stepup.md\`
+- `finding-01-graphql-apq-bypass.md`
+- `finding-02-verify-password-no-rate-limit.md`
+- `finding-03-update-password-no-stepup.md`
 
 ## Per-finding template
 
 Each finding file should have:
 1. Status (lead / validated / drafted / submitted / triaged / paid / closed)
-2. The finding summary (use \`triage-validation\`'s 7-Question Gate format)
+2. The finding summary (use `triage-validation`'s 7-Question Gate format)
 3. Reproduction steps with exact requests/responses
 4. Evidence inventory (path to redacted screenshots in ../evidence/)
 5. Severity reasoning + VRT mapping (if Bugcrowd)

--- a/scripts/hunt.sh
+++ b/scripts/hunt.sh
@@ -38,11 +38,12 @@ hunt() {
   mkdir -p "$dir/findings" "$dir/evidence"
 
   # ============== CLAUDE.md ==============
-  cat > "$dir/CLAUDE.md" <<CLAUDEMD
-# Engagement: $target
-
-**Target:** $target
-**Started:** $(date -u +"%Y-%m-%d")
+  # Write heading lines that require $target interpolation explicitly,
+  # then append the static body via a quoted heredoc (no shell injection risk).
+  printf '# Engagement: %s\n\n' "$target" > "$dir/CLAUDE.md"
+  printf '**Target:** %s\n' "$target" >> "$dir/CLAUDE.md"
+  printf '**Started:** %s\n' "$(date -u +"%Y-%m-%d")" >> "$dir/CLAUDE.md"
+  cat >> "$dir/CLAUDE.md" <<'CLAUDEMD'
 **Platform:** [TBD — Bugcrowd / HackerOne / Intigriti / Immunefi / private]
 **Program URL:** [paste the program page URL here]
 
@@ -98,8 +99,8 @@ Files in this folder:
 CLAUDEMD
 
   # ============== scope.md ==============
-  cat > "$dir/scope.md" <<SCOPEMD
-# Scope — $target
+  printf '# Scope — %s\n' "$target" > "$dir/scope.md"
+  cat >> "$dir/scope.md" <<'SCOPEMD'
 
 > Parse this from the program page (Bugcrowd / HackerOne / etc.) before
 > doing any active testing. \`/scope <asset>\` can verify individual assets.
@@ -151,8 +152,8 @@ CLAUDEMD
 SCOPEMD
 
   # ============== submissions.txt ==============
-  cat > "$dir/submissions.txt" <<SUBSEOF
-# Submissions tracker — $target
+  printf '# Submissions tracker — %s\n' "$target" > "$dir/submissions.txt"
+  cat >> "$dir/submissions.txt" <<'SUBSEOF'
 #
 # Format (tab-separated):
 # <UUID>  <severity>  <VRT-or-class>  <one-line title>
@@ -163,8 +164,8 @@ SCOPEMD
 SUBSEOF
 
   # ============== findings/README.md ==============
-  cat > "$dir/findings/README.md" <<FINDREADME
-# Findings — $target
+  printf '# Findings — %s\n' "$target" > "$dir/findings/README.md"
+  cat >> "$dir/findings/README.md" <<'FINDREADME'
 
 One markdown file per lead.
 
@@ -190,8 +191,8 @@ Each finding file should have:
 FINDREADME
 
   # ============== notes.md ==============
-  cat > "$dir/notes.md" <<NOTESMD
-# Notes — $target
+  printf '# Notes — %s\n' "$target" > "$dir/notes.md"
+  cat >> "$dir/notes.md" <<'NOTESMD'
 
 > Running scratchpad. Leads, hypotheses, dead ends.
 
@@ -209,7 +210,7 @@ FINDREADME
 NOTESMD
 
   # ============== .gitignore ==============
-  cat > "$dir/.gitignore" <<GITIGNORE
+  cat > "$dir/.gitignore" <<'GITIGNORE'
 # Never commit raw evidence — contains live cookies, PII, HARs
 evidence/
 


### PR DESCRIPTION
Closes #13. Lands @sseshachala's security fixes (from #15) with two triage-found defects corrected, since these bugs are **live on `main` right now**.

Built on their commit (preserved) + one hardening commit on top.

## The 5 bugs from #13

| # | Bug | Status |
|---|-----|--------|
| 1 | Path traversal in `cmd_recon` | ✅ fixed (#15) + **hardened**: their `str.startswith` check was bypassable (`recon` ⊂ `recon-evil`) → now a real ancestry test |
| 2 | Arbitrary write via `--out` | ✅ fixed (#15) + **hardened**: same prefix-trick bypass → ancestry test |
| 3 | Q5 duplicate-detection inverted | ✅ fixed (#15) — `"duplicate"` removed from novelty signals |
| 4 | Shell injection via unquoted heredoc | ✅ fixed (#15: quoted heredocs + `printf` for `$target`) + **fixed regression**: the leftover `\`` escapes were rendering literally and corrupting every generated file → de-escaped |
| 5 | TLS `CERT_NONE` under `--proxy` | ⚠️ loud warning (from #15). Kept as-is: disabling verification is inherent to routing through Burp's self-signed CA; a hard gate would break the primary workflow |

## Verification (all run locally on this branch)
- `cbh.py` compiles. Containment: `acme.com`/`sub.acme.com` accepted; `../../tmp/evil`, `../recon-evil/x`, `../../../etc/passwd` rejected. `--out`: `report.md` accepted; `../<cwd>-evil/x.md` rejected.
- `hunt.sh`: valid bash; backticks now render (`` `scope.md` `` not `` \`scope.md\` ``); injection target `$(id>/tmp/PWNED)` **not executed**, written literally.

## Scan
Clean — no client identifiers, secrets, or stray network calls. Diff scoped to `scripts/cbh.py` + `scripts/hunt.sh`.

Credit to @sseshachala for the report (#13) and initial fix (#15). #15 can be closed in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)