### PR TITLE
Ship as a Claude Code plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,35 @@
+{
+  "name": "elementalsouls",
+  "owner": {
+    "name": "Sachin Sharma",
+    "url": "https://github.com/elementalsouls"
+  },
+  "metadata": {
+    "description": "Offensive-security skill bundles for Claude Code by ElementalSoul.",
+    "version": "2.1.0"
+  },
+  "plugins": [
+    {
+      "name": "claude-bughunter",
+      "source": "./",
+      "description": "71-skill bug-hunting & external red-team bundle — 48 hunt-* web/vuln-class + framework skills, enterprise platform attack chains (M365/Entra, Okta, SharePoint, vCenter, SSL-VPN, APK), recon/OSINT, reporting & validation gates, Burp MCP integration. Skills auto-load by topic; 15 slash commands.",
+      "version": "2.1.0",
+      "author": {
+        "name": "Sachin Sharma",
+        "url": "https://github.com/elementalsouls"
+      },
+      "homepage": "https://elementalsouls.github.io/Claude-BugHunter",
+      "category": "security",
+      "tags": [
+        "security",
+        "offensive-security",
+        "bug-bounty",
+        "red-team",
+        "pentest",
+        "recon",
+        "osint",
+        "hunt"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "claude-bughunter",
+  "description": "71-skill bug-hunting & external red-team bundle for Claude Code — 48 hunt-* web/vuln-class + framework skills, enterprise platform attack chains (M365/Entra, Okta, SharePoint, vCenter, SSL-VPN, APK), recon/OSINT, reporting & validation gates, and Burp MCP integration. Skills auto-load by topic; 15 slash commands included.",
+  "version": "2.1.0",
+  "author": {
+    "name": "Sachin Sharma",
+    "url": "https://github.com/elementalsouls"
+  },
+  "homepage": "https://elementalsouls.github.io/Claude-BugHunter",
+  "repository": "https://github.com/elementalsouls/Claude-BugHunter",
+  "license": "MIT"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ versioning is loosely [SemVer](https://semver.org/) at the bundle level.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+- **Claude Code plugin marketplace** — `.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json`
+  make the bundle installable natively: `/plugin marketplace add elementalsouls/Claude-BugHunter`
+  then `/plugin install claude-bughunter@elementalsouls`. Skills load namespaced under
+  `claude-bughunter:` and update on version bump. The `scripts/install.sh` copy method stays as a
+  fallback. This is the convention used by Anthropic's own marketplaces and Trail of Bits.
 
 ## [2.1] - 2026-06-05
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ All triggered automatically by topic — describe what you're testing in plain E
 
 ## Quickstart
 
+**Option A — install as a Claude Code plugin (recommended).** From inside Claude Code:
+
+```text
+/plugin marketplace add elementalsouls/Claude-BugHunter
+/plugin install claude-bughunter@elementalsouls
+```
+
+All 71 skills + 15 commands load namespaced under `claude-bughunter:` and update when you bump the plugin version — no files copied into `~/.claude/`.
+
+**Option B — copy install (no plugin system / pin to a clone):**
+
 ```bash
 git clone https://github.com/elementalsouls/Claude-BugHunter.git
 cd Claude-BugHunter


### PR DESCRIPTION
Makes Claude-BugHunter installable via the native **plugin-marketplace** mechanism — the convention the ecosystem has converged on (Anthropic's official marketplaces, Trail of Bits) and what users/contributors now expect, vs the legacy copy-to-`~/.claude/skills` install.

## Install (after merge)
```
/plugin marketplace add elementalsouls/Claude-BugHunter
/plugin install claude-bughunter@elementalsouls
```

## What's added
- `.claude-plugin/plugin.json` — plugin manifest (`name`, `description`, `version` 2.1.0, `author`, homepage/repo/license).
- `.claude-plugin/marketplace.json` — marketplace (`name: elementalsouls`, `owner`, one plugin `claude-bughunter`, `source: "./"`, category `security`, tags).
- README Quickstart: plugin install as Option A (recommended), `install.sh` copy as Option B (fallback).
- CHANGELOG entry.

## Design notes
- **Whole repo = the plugin** (`source: "./"`) — `skills/` (71) and `commands/` (15) are already at the plugin root, so **zero files move** and the copy-install still works unchanged.
- Skills load **namespaced** as `claude-bughunter:hunt-xss` etc. (can't collide with a user's other skills).
- Single plugin for now (matches the "install once, all skills auto-load" design). Could later split into category sub-plugins like Trail of Bits if desired.
- JSON validated; structure checked against the documented schema.

You can test the marketplace locally before relying on the remote: `/plugin marketplace add ./` from a clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)