### PR TITLE
README: add Cyber Verification Program (CVP) heads-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,6 +735,8 @@ The skills include validation gates that auto-trigger when you point Claude at u
 
 The bundle explicitly **excludes**: weaponizing 0-days against unauthorized targets, post-exploitation tooling, malware development, mass-targeting infrastructure. See [`SECURITY.md`](SECURITY.md) for the full posture.
 
+> **Heads-up — Anthropic runtime cyber safeguards.** Anthropic's models apply real-time safeguards that **block "vulnerability exploitation or offensive security tooling development" by default** — so even *authorized, in-scope* work can hit a refusal that isn't this bundle's doing. If you do authorized offensive security (pentest / bug bounty / red team), enroll in Anthropic's **free, application-based [Cyber Verification Program (CVP)](https://claude.com/form/cyber-use-case)** to get safeguards adjusted for legitimate dual-use work. (Mass data exfiltration and ransomware development stay prohibited and are *not* adjustable.) Details: [Anthropic — real-time cyber safeguards](https://support.claude.com/en/articles/14604842-real-time-cyber-safeguards-on-claude).
+
 ---
 
 ## Documentation


### PR DESCRIPTION
Anthropic's models apply real-time cyber safeguards that block "vulnerability exploitation or offensive security tooling development" **by default** — so users running this bundle on *authorized* targets can hit a guardrail refusal that isn't the skills' fault. Adds a short note in the Authorization section pointing to Anthropic's **free, application-based [Cyber Verification Program](https://claude.com/form/cyber-use-case)** so users know how to get safeguards adjusted for legitimate dual-use work. Sourced verbatim from [Anthropic's real-time cyber-safeguards article](https://support.claude.com/en/articles/14604842-real-time-cyber-safeguards-on-claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)