### PR TITLE
Run skills on OpenCode, Codex, and Hermes Agent (verified live)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ versioning is loosely [SemVer](https://semver.org/) at the bundle level.
   then `/plugin install claude-bughunter@elementalsouls`. Skills load namespaced under
   `claude-bughunter:` and update on version bump. The `scripts/install.sh` copy method stays as a
   fallback. This is the convention used by Anthropic's own marketplaces and Trail of Bits.
+- **Multi-harness install** — the 71 Agent Skills now run on **OpenCode, OpenAI Codex CLI, and
+  Hermes Agent**, not just Claude Code. `scripts/install.sh` gains `--agents` (→ `~/.agents/skills/`,
+  read by Codex + OpenCode), `--hermes` (→ `~/.hermes/skills/`), `--all`, and `--burp-mcp` (translates
+  the existing Burp MCP into each harness's config via `scripts/setup_harness_mcp.py`; OpenCode JSON +
+  Codex TOML + Hermes YAML written). Verified end-to-end on OpenCode, Codex, and Hermes
+  (skills load + live Burp MCP connects). Slash commands, the plugin marketplace, and `hunt-dispatch`
+  remain Claude-Code-only. New guide: `docs/multi-harness.md`.
+
+### Fixed
+- `hunt-ntlm-info`: quoted the `description` — it contained an unquoted `` `WWW-Authenticate: NTLM` ``
+  (`: ` makes strict YAML parsers read a nested mapping). Claude/OpenCode/Hermes tolerated it; **Codex
+  rejected it**. Surfaced by real multi-harness testing.
+
+### Changed
+- `install.sh --agents` **auto-truncates** descriptions > 1024 chars to ≤1024 in the `~/.agents/skills`
+  (Codex) copy only — Codex hard-rejects longer ones; `~/.claude`/`~/.hermes` keep full descriptions.
+  Affects the 3 aggregator router skills.
+- `scripts/lint_skills.py` hardened: adds a YAML-safety check (catches unquoted-value-with-`: `, the
+  `hunt-ntlm-info` bug class) and notes Codex's 1024 limit in the over-length message.
 
 ## [2.1] - 2026-06-05
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,11 +42,24 @@ chmod +x scripts/install.sh
 ```
 
 This copies:
-- All 51 skills → `~/.claude/skills/`
+- All 71 skills → `~/.claude/skills/`
 - All 15 slash commands → `~/.claude/commands/`
 - The `hunt` shell command → `~/.claude/scripts/hunt.sh` (sourced from your `.zshrc` or `.bashrc` automatically)
 
-Existing skills with the same name are backed up (e.g. `bugcrowd-reporting.backup-20260505-153000`) so re-runs are non-destructive.
+Existing skills with the same name are backed up to `~/.claude/install-backups/<timestamp>/` — **outside** the skills/commands directories, so backups never load as duplicate skills. Re-runs are non-destructive.
+
+### Run on other harnesses (OpenCode · Codex · Hermes)
+
+The skills are plain Agent Skills, so they also run outside Claude Code:
+
+```bash
+./scripts/install.sh --all          # also installs to ~/.agents/skills (Codex + OpenCode) and ~/.hermes/skills (Hermes)
+./scripts/install.sh --agents       # just Codex + OpenCode
+./scripts/install.sh --hermes       # just Hermes
+./scripts/install.sh --agents --burp-mcp   # also wire your Burp MCP into those harnesses
+```
+
+Slash commands, the plugin marketplace, and the `/hunt` engine are Claude-Code-only; other harnesses get the skill knowledge + Burp MCP. Full details and per-harness MCP snippets: [`docs/multi-harness.md`](docs/multi-harness.md).
 
 ## Step 3 — (Optional) Set up Burp MCP
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ cd Claude-BugHunter
 bash scripts/install.sh        # copies skills + commands into ~/.claude/
 ```
 
+**Also runs on OpenCode · Codex · Hermes Agent.** The skills are plain Agent Skills, so the *knowledge* ports beyond Claude Code: `bash scripts/install.sh --all` installs them to every harness's path (`--burp-mcp` also wires Burp). Slash commands + the `/hunt` engine stay Claude-Code-only. See the [multi-harness guide](docs/multi-harness.md).
+
 That's it. Open Claude Code and describe what you're testing in plain English — the right skill loads automatically, no invocation by name:
 
 ```text

--- a/docs/multi-harness.md
+++ b/docs/multi-harness.md
@@ -1,0 +1,81 @@
+---
+title: Multi-harness install
+nav_order: 3
+description: Run the Claude-BugHunter skills on OpenCode, Codex, and Hermes Agent — not just Claude Code.
+---
+
+# Multi-harness install
+
+The 71 skills are plain **Agent Skills** (`SKILL.md` = `name` + `description` frontmatter + Markdown). That format is an open standard, so the *knowledge* runs on more than Claude Code. This page shows how to install it on **OpenCode**, **OpenAI Codex CLI**, and **Hermes Agent**.
+
+> **What ports and what doesn't.** The **71 skills** (payloads, methodology, bypass tables, disclosed-report patterns) port to every harness below. The **`/hunt` slash commands, the plugin marketplace, and the `hunt-dispatch` subagent routing are Claude-Code-specific** and do **not** port — other harnesses get the knowledge, not the orchestration engine. **Burp MCP** ports to all of them (it's just an MCP server).
+
+## Compatibility matrix (verified mid-2026)
+
+| Harness | Reads `SKILL.md`? | Skill path it loads | MCP (Burp) | Slash commands |
+|---|---|---|---|---|
+| **Claude Code** (baseline) | ✅ native | `~/.claude/skills/` | ✅ | ✅ (`/hunt`, …) |
+| **OpenCode** | ✅ native | reads `~/.claude/skills/` **and** `~/.agents/skills/` | ✅ `opencode.json` | ✅ own format |
+| **Codex CLI** | ✅ native | `~/.agents/skills/` (does *not* read `~/.claude/`) | ✅ `~/.codex/config.toml` | ✅ own format |
+| **Hermes Agent** | ✅ (agentskills.io) | `~/.hermes/skills/` | ✅ | ✅ own format |
+
+**Key:** `~/.agents/skills/` is the shared path read by **Codex + OpenCode**. So two copies cover everything: `~/.claude/skills/` (Claude) + `~/.agents/skills/` (Codex + OpenCode), plus `~/.hermes/skills/` for Hermes. Required frontmatter is identical across all four (`name` lowercase-hyphen ≤64, `description` ≤1024) — our `scripts/lint_skills.py` enforces it, so **no per-skill conversion is needed**.
+
+## Install
+
+One command installs the skills to every harness's path (copy install; existing skills are backed up outside the loading path):
+
+```bash
+git clone https://github.com/elementalsouls/Claude-BugHunter.git
+cd Claude-BugHunter
+bash scripts/install.sh --all          # Claude + ~/.agents/skills (Codex/OpenCode) + ~/.hermes/skills
+```
+
+Pick specific harnesses instead:
+
+```bash
+bash scripts/install.sh                 # Claude Code only (default)
+bash scripts/install.sh --agents        # + Codex & OpenCode (~/.agents/skills)
+bash scripts/install.sh --hermes        # + Hermes Agent (~/.hermes/skills)
+```
+
+- **OpenCode** already reads `~/.claude/skills/`, so the plain `install.sh` (no flags) is enough for OpenCode — you don't need `--agents` for it. `--agents` exists mainly for **Codex** (which reads only `~/.agents/skills/`).
+  - *Caveat (verified):* OpenCode reads **both** `~/.claude/skills/` and `~/.agents/skills/`. If both are populated (e.g. you ran `--all` for Codex too), OpenCode logs harmless `duplicate skill name` warnings and loads one copy — all 71 skills still work. Only populate `~/.agents/skills/` if you actually use Codex.
+- **Codex is the strict parser** (verified by testing): it hard-rejects descriptions > 1024 chars and invalid YAML, where Claude/OpenCode/Hermes are lenient. So `install.sh` **auto-truncates** any description > 1024 to ≤1024 **only in the `~/.agents/skills` (Codex) copy** — your `~/.claude` and `~/.hermes` copies keep the full descriptions (incl. non-English trigger words). The install logs which were truncated (today: the 3 aggregator router skills). `--normalize-frontmatter` additionally strips the non-standard `sources:`/`report_count:` keys (optional — Codex tolerates them).
+
+## Burp MCP on other harnesses
+
+Your Burp MCP is a stdio command, so it translates 1:1. `install.sh --burp-mcp` (with a harness flag) wires it automatically by translating your **existing** Claude Code Burp definition (from `~/.claude.json`) — it backs up each config first:
+
+```bash
+bash scripts/install.sh --agents --burp-mcp     # writes OpenCode + Codex MCP config; prints Hermes guidance
+```
+
+Or do it manually (replace the jar path / port with yours):
+
+**OpenCode** — `~/.config/opencode/opencode.json`
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "burp": {
+      "type": "local",
+      "command": ["java", "-jar", "~/.BurpSuite/mcp-proxy/mcp-proxy-all.jar", "--sse-url", "http://127.0.0.1:9876"],
+      "enabled": true
+    }
+  }
+}
+```
+
+**Codex** — `~/.codex/config.toml`
+```toml
+[mcp_servers.burp]
+command = "java"
+args = ["-jar", "~/.BurpSuite/mcp-proxy/mcp-proxy-all.jar", "--sse-url", "http://127.0.0.1:9876"]
+```
+
+**Hermes** — see the [Hermes MCP guide](https://hermes-agent.nousresearch.com/docs/guides/use-mcp-with-hermes); use the same `java -jar … --sse-url …` command.
+
+## Verify it loaded
+- **OpenCode / Codex / Hermes:** open the tool and describe a task (e.g. *"test this endpoint for SSRF"*) — the matching `hunt-*` skill should auto-load by its description, same as in Claude Code.
+- **Hermes:** `hermes skills` should list the bundle from `~/.hermes/skills/`.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,71 +1,101 @@
 #!/usr/bin/env bash
 # =====================================================================
-# install.sh — Install Claude-BugHunter bundle
+# install.sh — Install Claude-BugHunter bundle (multi-harness)
 #
-# Copies all bundled content into ~/.claude/:
-#   - skills/*       → ~/.claude/skills/
-#   - commands/*.md  → ~/.claude/commands/
+# DEFAULT (no flags): installs into ~/.claude/ for Claude Code —
+#   - skills/*        → ~/.claude/skills/
+#   - commands/*.md   → ~/.claude/commands/
 #   - scripts/hunt.sh → ~/.claude/scripts/hunt.sh + sourced from shell rc
+#   (unchanged from prior behavior)
 #
-# Idempotent: safe to re-run. Existing skills/commands with the same
-# name are backed up before overwrite.
-# Requires: bash.
+# MULTI-HARNESS FLAGS (skills only — the 71 SKILL.md files. Slash commands,
+# the plugin marketplace, and the /hunt engine are Claude-Code-specific and do
+# NOT port; other harnesses get the knowledge, not the orchestration):
+#   --agents    also copy skills → ~/.agents/skills/   (read by Codex + OpenCode)
+#   --hermes    also copy skills → ~/.hermes/skills/    (Hermes Agent)
+#   --all       Claude (default) + --agents + --hermes
+#   --burp-mcp  wire your existing Burp MCP server into the selected harnesses'
+#               configs (opt-in; backs up each config first; uses python3)
+#   --normalize-frontmatter
+#               strip non-standard keys (sources/report_count) from the NON-Claude
+#               copies — only needed if a harness rejects unknown frontmatter keys
+#   -h|--help   show this help
+#
+# Idempotent. Existing skills/commands are backed up OUTSIDE the loading path
+# (~/.claude/install-backups/<ts>/) so backups never load as duplicate skills.
+# Requires: bash. (--burp-mcp also requires python3.)
 # =====================================================================
-
 set -e
 
 REPO_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
-SKILLS_DEST="$HOME/.claude/skills"
-COMMANDS_DEST="$HOME/.claude/commands"
-SCRIPTS_DEST="$HOME/.claude/scripts"
-# Backups go OUTSIDE the skills/commands dirs — anything left inside them is
-# loaded by Claude Code as a (duplicate) skill/command. One timestamped folder
-# per run, created lazily only if something is actually backed up.
 BACKUP_DEST="$HOME/.claude/install-backups/$(date +%Y%m%d-%H%M%S)"
 
-mkdir -p "$SKILLS_DEST" "$COMMANDS_DEST" "$SCRIPTS_DEST"
+usage() { sed -n '2,30p' "$0" | sed 's/^#\{0,1\} \{0,1\}//'; }
 
-echo "Installing Claude-BugHunter bundle from $REPO_DIR"
-echo ""
-
-# === Install skills ===
-echo "Skills →  $SKILLS_DEST"
-for skill_dir in "$REPO_DIR/skills"/*/; do
-  skill_name="$(basename "$skill_dir")"
-  if [ -d "$SKILLS_DEST/$skill_name" ] && [ ! -L "$SKILLS_DEST/$skill_name" ]; then
-    mkdir -p "$BACKUP_DEST/skills"
-    mv "$SKILLS_DEST/$skill_name" "$BACKUP_DEST/skills/$skill_name"
-    echo "  ↺ Backed up existing $skill_name → $BACKUP_DEST/skills/"
-  fi
-  cp -r "$skill_dir" "$SKILLS_DEST/$skill_name"
-  echo "  ✓ Installed skill: $skill_name"
+DO_AGENTS=0; DO_HERMES=0; DO_MCP=0; NORMALIZE=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --agents) DO_AGENTS=1 ;;
+    --hermes) DO_HERMES=1 ;;
+    --all)    DO_AGENTS=1; DO_HERMES=1 ;;
+    --burp-mcp) DO_MCP=1 ;;
+    --normalize-frontmatter) NORMALIZE=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1 (try --help)" >&2; exit 2 ;;
+  esac
+  shift
 done
 
+SKILL_COUNT="$(find "$REPO_DIR/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+
+# Copy every skill folder into <dest>, backing up any existing same-name dir
+# OUTSIDE the loading path. $2 is a label used for the backup subfolder + logging.
+install_skills() {
+  local dest="$1" label="$2" name sm
+  mkdir -p "$dest"
+  echo "Skills →  $dest   ($label)"
+  for skill_dir in "$REPO_DIR/skills"/*/; do
+    name="$(basename "$skill_dir")"
+    if [ -d "$dest/$name" ] && [ ! -L "$dest/$name" ]; then
+      mkdir -p "$BACKUP_DEST/$label"
+      mv "$dest/$name" "$BACKUP_DEST/$label/$name"
+    fi
+    cp -r "$skill_dir" "$dest/$name"
+  done
+  echo "  ✓ $SKILL_COUNT skills installed"
+  echo ""
+}
+
+echo "Installing Claude-BugHunter bundle from $REPO_DIR"
+if [ "$DO_AGENTS" = "1" ] || [ "$DO_HERMES" = "1" ]; then echo "(multi-harness mode)"; fi
 echo ""
 
-# === Install commands ===
+# === Claude Code (always) — skills + commands + hunt.sh ===
+install_skills "$HOME/.claude/skills" "skills"
+
+COMMANDS_DEST="$HOME/.claude/commands"
 if [ -d "$REPO_DIR/commands" ]; then
-  echo "Commands →  $COMMANDS_DEST"
+  mkdir -p "$COMMANDS_DEST"
+  echo "Commands →  $COMMANDS_DEST   (Claude Code only)"
   for cmd_file in "$REPO_DIR/commands"/*.md; do
     [ -e "$cmd_file" ] || continue
     cmd_name="$(basename "$cmd_file")"
     if [ -f "$COMMANDS_DEST/$cmd_name" ] && [ ! -L "$COMMANDS_DEST/$cmd_name" ]; then
       mkdir -p "$BACKUP_DEST/commands"
       mv "$COMMANDS_DEST/$cmd_name" "$BACKUP_DEST/commands/$cmd_name"
-      echo "  ↺ Backed up existing $cmd_name → $BACKUP_DEST/commands/"
     fi
     cp "$cmd_file" "$COMMANDS_DEST/$cmd_name"
-    echo "  ✓ Installed command: /${cmd_name%.md}"
   done
+  echo "  ✓ commands installed"
   echo ""
 fi
 
-# === Install hunt shell command ===
+SCRIPTS_DEST="$HOME/.claude/scripts"
+mkdir -p "$SCRIPTS_DEST"
 cp "$REPO_DIR/scripts/hunt.sh" "$SCRIPTS_DEST/hunt.sh"
 chmod +x "$SCRIPTS_DEST/hunt.sh"
 echo "  ✓ Installed hunt shell command at $SCRIPTS_DEST/hunt.sh"
 
-# Detect shell rc file
 SHELL_RC=""
 if [ -n "${ZDOTDIR:-}" ] && [ -f "$ZDOTDIR/.zshrc" ]; then
   SHELL_RC="$ZDOTDIR/.zshrc"
@@ -74,7 +104,6 @@ elif [ -f "$HOME/.zshrc" ]; then
 elif [ -f "$HOME/.bashrc" ]; then
   SHELL_RC="$HOME/.bashrc"
 fi
-
 if [ -n "$SHELL_RC" ]; then
   if grep -q "claude/scripts/hunt.sh" "$SHELL_RC" 2>/dev/null; then
     echo "  ✓ hunt.sh already sourced from $SHELL_RC"
@@ -85,25 +114,83 @@ if [ -n "$SHELL_RC" ]; then
     echo "  ✓ Added 'source ~/.claude/scripts/hunt.sh' to $SHELL_RC"
   fi
 else
-  echo "  ⚠ Could not detect shell rc file. Manually add this line to your shell startup:"
+  echo "  ⚠ Could not detect shell rc file. Manually add:"
   echo "       source ~/.claude/scripts/hunt.sh"
 fi
-
-# Make it available in the current shell too
 # shellcheck disable=SC1091
 source "$SCRIPTS_DEST/hunt.sh" 2>/dev/null || true
-
 echo ""
+
+# === Extra harness targets (skills only) ===
+if [ "$DO_AGENTS" = "1" ]; then
+  install_skills "$HOME/.agents/skills" "agents"
+  # Codex (which reads ~/.agents/skills) HARD-rejects descriptions > 1024 chars.
+  # Auto-truncate over-length descriptions in THIS copy only — ~/.claude and
+  # ~/.hermes keep full descriptions. Optional --normalize-frontmatter also strips
+  # non-standard keys (sources/report_count). Python3 only; skipped if absent.
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$HOME/.agents/skills" "$NORMALIZE" <<'PY'
+import os, re, sys
+root, strip_extra = sys.argv[1], sys.argv[2] == "1"
+LIMIT = 1024
+for name in sorted(os.listdir(root)):
+    p = os.path.join(root, name, "SKILL.md")
+    if not os.path.isfile(p):
+        continue
+    lines = open(p, encoding="utf-8").read().split("\n")
+    out, changed = [], False
+    for i, line in enumerate(lines):
+        # frontmatter sits at the very top; only touch the first ~12 lines
+        m = re.match(r'^description:\s*(.*)$', line) if i < 12 else None
+        if m:
+            val = m.group(1)
+            quoted = len(val) >= 2 and val[0] == val[-1] and val[0] in "\"'"
+            inner = val[1:-1] if quoted else val
+            if len(inner) > LIMIT:
+                cut = inner[:LIMIT - 2].rsplit(" ", 1)[0].rstrip(" ,;:—-")
+                line = 'description: "' + cut + '…"'
+                changed = True
+                print(f"    ✂ truncated {name} description {len(inner)}→{len(cut)+1} (Codex 1024 limit)")
+        if strip_extra and i < 12 and re.match(r'^(sources|report_count):\s', line):
+            changed = True
+            continue
+        out.append(line)
+    if changed:
+        open(p, "w", encoding="utf-8").write("\n".join(out))
+PY
+  fi
+fi
+if [ "$DO_HERMES" = "1" ]; then install_skills "$HOME/.hermes/skills" "hermes"; fi
+
+# === Opt-in: wire the existing Burp MCP into the selected harnesses ===
+if [ "$DO_MCP" = "1" ]; then
+  MCP_TARGETS=""
+  if [ "$DO_AGENTS" = "1" ]; then MCP_TARGETS="$MCP_TARGETS --opencode --codex"; fi
+  if [ "$DO_HERMES" = "1" ]; then MCP_TARGETS="$MCP_TARGETS --hermes"; fi
+  if [ -z "$MCP_TARGETS" ]; then
+    echo "  ⚠ --burp-mcp needs a harness flag (--agents/--hermes/--all). Skipping."
+  elif command -v python3 >/dev/null 2>&1; then
+    # shellcheck disable=SC2086
+    python3 "$REPO_DIR/scripts/setup_harness_mcp.py" $MCP_TARGETS || \
+      echo "  ⚠ Burp MCP wiring reported an issue — see scripts/setup_harness_mcp.py output."
+  else
+    echo "  ⚠ python3 not found — skipping --burp-mcp. See docs/multi-harness.md for manual snippets."
+  fi
+  echo ""
+fi
+
 echo "============================================"
 echo "✓ Install complete"
 echo "============================================"
 echo ""
-echo "Skills installed at:   $SKILLS_DEST"
-echo "Commands installed at: $COMMANDS_DEST"
-echo "Shell command at:      $SCRIPTS_DEST/hunt.sh"
+echo "Claude Code:   $HOME/.claude/skills  (+ commands, hunt.sh)"
+if [ "$DO_AGENTS" = "1" ]; then echo "Codex+OpenCode: $HOME/.agents/skills"; fi
+if [ "$DO_HERMES" = "1" ]; then echo "Hermes Agent:  $HOME/.hermes/skills"; fi
+if [ -d "$BACKUP_DEST" ]; then echo "Backups:       $BACKUP_DEST  (outside loading paths)"; fi
 echo ""
-echo "Next: open a new terminal (or 'source $SHELL_RC') and try:"
-echo "    hunt acme-test"
+if [ "$DO_AGENTS" = "0" ] && [ "$DO_HERMES" = "0" ]; then
+  echo "Run other harnesses too:  bash scripts/install.sh --all"
+  echo "See also: docs/multi-harness.md"
+fi
 echo ""
-echo "Optional — refresh vendored upstream skills:"
-echo "    ./scripts/install-community-skills.sh"
+echo "Next: open a new terminal (or 'source $SHELL_RC') and try:  hunt acme-test"

--- a/scripts/lint_skills.py
+++ b/scripts/lint_skills.py
@@ -116,6 +116,28 @@ def split_frontmatter(raw):
     return fm, body, None
 
 
+def yaml_safety_errors(name, raw):
+    """Catch frontmatter a STRICT YAML parser (e.g. Codex) rejects but our lenient
+    regex parser accepts — chiefly an unquoted value containing ': ' (colon-space),
+    which YAML reads as a nested mapping. This is the hunt-ntlm-info bug class."""
+    errs = []
+    if not raw.startswith("---"):
+        return errs
+    lines = raw.split("\n")
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            break
+        m = re.match(r"^([A-Za-z0-9_-]+):\s*(.*)$", lines[i])
+        if not m or not m.group(2):
+            continue
+        val = m.group(2)
+        quoted = len(val) >= 2 and val[0] == val[-1] and val[0] in "\"'"
+        if not quoted and ": " in val:
+            errs.append(f"{name}: frontmatter `{m.group(1)}` is unquoted and contains ': ' — "
+                        f"wrap the value in double quotes (strict YAML parsers like Codex reject it)")
+    return errs
+
+
 def lint_skill(skill_dir, denylist):
     errors, warnings = [], []
     name = os.path.basename(skill_dir.rstrip("/"))
@@ -128,6 +150,7 @@ def lint_skill(skill_dir, denylist):
     fm, body, fm_err = split_frontmatter(raw)
     if fm_err:
         errors.append(f"{name}: {fm_err}")
+    errors += yaml_safety_errors(name, raw)
     # name
     fn = fm.get("name", "")
     if not fn:
@@ -142,7 +165,8 @@ def lint_skill(skill_dir, denylist):
     if not desc:
         errors.append(f"{name}: frontmatter missing `description`")
     elif len(desc) > MAX_DESC:
-        msg = f"{name}: description {len(desc)} chars > {MAX_DESC} limit"
+        msg = (f"{name}: description {len(desc)} chars > {MAX_DESC} limit "
+               f"(Codex rejects >1024; install.sh --agents auto-truncates the Codex copy)")
         (warnings if name in DESC_LIMIT_GRANDFATHERED else errors).append(msg)
     elif len(desc) < 40:
         warnings.append(f"{name}: description very short ({len(desc)} chars) — weak trigger surface")

--- a/scripts/setup_harness_mcp.py
+++ b/scripts/setup_harness_mcp.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+setup_harness_mcp.py — wire your EXISTING Burp MCP server into other harnesses.
+
+Reads your real Burp MCP definition from ~/.claude.json (the stdio command Claude
+Code already uses — we never invent one) and writes the equivalent into each
+selected harness's config, backing up the file first. Idempotent.
+
+Usage:
+    python3 scripts/setup_harness_mcp.py [--opencode] [--codex] [--hermes] [--dry-run]
+    # optional overrides if auto-discovery fails:
+    python3 scripts/setup_harness_mcp.py --opencode --command java --arg -jar --arg /path/mcp-proxy-all.jar --arg --sse-url --arg http://127.0.0.1:9876
+
+Schema notes (verified against each tool's docs, mid-2026):
+  - OpenCode  ~/.config/opencode/opencode.json  →  mcp.<name> = {type:"local", command:[...], enabled:true}   (JSON — written here)
+  - Codex     ~/.codex/config.toml              →  [mcp_servers.<name>] command/args/env                      (TOML — appended here)
+  - Hermes    ~/.hermes/config.yaml             →  MCP block (schema not independently verified) — we PRINT the
+              command + the Hermes MCP guide instead of blind-writing YAML.
+"""
+import argparse, json, os, shutil, sys, time
+
+CLAUDE_JSON = os.path.expanduser("~/.claude.json")
+
+
+def discover_burp():
+    """Return (command:str, args:list[str], env:dict) for the 'burp' MCP server from ~/.claude.json."""
+    if not os.path.isfile(CLAUDE_JSON):
+        return None
+    try:
+        data = json.load(open(CLAUDE_JSON, encoding="utf-8"))
+    except Exception:
+        return None
+    hits = []
+
+    def walk(o):
+        if isinstance(o, dict):
+            for k, v in o.items():
+                if k in ("mcpServers", "mcp_servers", "mcp") and isinstance(v, dict):
+                    for name, defn in v.items():
+                        if "burp" in name.lower() and isinstance(defn, dict) and defn.get("command"):
+                            hits.append(defn)
+                walk(v)
+        elif isinstance(o, list):
+            for x in o:
+                walk(x)
+
+    walk(data)
+    if not hits:
+        return None
+    d = hits[0]
+    return d.get("command"), list(d.get("args", [])), dict(d.get("env", {}) or {})
+
+
+def backup(path):
+    if os.path.exists(path):
+        b = f"{path}.bak-{time.strftime('%Y%m%d-%H%M%S')}"
+        shutil.copy2(path, b)
+        print(f"    ↺ backed up {path} → {b}")
+
+
+def toml_str(s):
+    return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def write_opencode(cmd, args, env, dry):
+    path = os.path.expanduser("~/.config/opencode/opencode.json")
+    cfg = {}
+    if os.path.isfile(path):
+        try:
+            cfg = json.load(open(path, encoding="utf-8"))
+        except Exception:
+            print(f"  ✗ OpenCode: {path} is not valid JSON — skipping (fix it or edit manually).")
+            return
+    cfg.setdefault("$schema", "https://opencode.ai/config.json")
+    mcp = cfg.setdefault("mcp", {})
+    entry = {"type": "local", "command": [cmd] + args, "enabled": True}
+    if env:
+        entry["environment"] = env
+    if mcp.get("burp") == entry:
+        print("  = OpenCode: burp MCP already configured (no change).")
+        return
+    mcp["burp"] = entry
+    print(f"  → OpenCode: set mcp.burp in {path}")
+    if dry:
+        print("      [dry-run] " + json.dumps(entry))
+        return
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    backup(path)
+    json.dump(cfg, open(path, "w", encoding="utf-8"), indent=2)
+    open(path, "a").write("\n")
+    print("  ✓ OpenCode burp MCP written.")
+
+
+def write_codex(cmd, args, env, dry):
+    path = os.path.expanduser("~/.codex/config.toml")
+    existing = open(path, encoding="utf-8").read() if os.path.isfile(path) else ""
+    if "[mcp_servers.burp]" in existing:
+        print("  = Codex: [mcp_servers.burp] already present (no change).")
+        return
+    lines = ["", "[mcp_servers.burp]", f"command = {toml_str(cmd)}",
+             "args = [" + ", ".join(toml_str(a) for a in args) + "]"]
+    if env:
+        lines.append("")
+        lines.append("[mcp_servers.burp.env]")
+        for k, v in env.items():
+            lines.append(f"{k} = {toml_str(str(v))}")
+    block = "\n".join(lines) + "\n"
+    print(f"  → Codex: append [mcp_servers.burp] to {path}")
+    if dry:
+        print("      [dry-run]\n" + "\n".join("        " + l for l in block.splitlines()))
+        return
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    backup(path)
+    with open(path, "a", encoding="utf-8") as f:
+        if existing and not existing.endswith("\n"):
+            f.write("\n")
+        f.write(block)
+    print("  ✓ Codex burp MCP appended.  (alt: `codex mcp add burp -- " + " ".join([cmd] + args) + "`)")
+
+
+def write_hermes(cmd, args, env, dry):
+    # Hermes schema (verified): top-level `mcp_servers: <name>: {command, args, env}`.
+    # No PyYAML dependency, so we only WRITE when we can do it safely (append a new
+    # top-level block when `mcp_servers:` is absent). If it already exists, we PRINT
+    # the block rather than risk an unparsed merge.
+    path = os.path.expanduser("~/.hermes/config.yaml")
+    body = ["mcp_servers:", "  burp:", f"    command: {json.dumps(cmd)}",
+            "    args: [" + ", ".join(json.dumps(a) for a in args) + "]"]
+    if env:
+        body.append("    env:")
+        for k, v in env.items():
+            body.append(f"      {k}: {json.dumps(str(v))}")
+    block = "\n" + "\n".join(body) + "\n"
+    existing = open(path, encoding="utf-8").read() if os.path.isfile(path) else ""
+    has_mcp = existing.startswith("mcp_servers:") or "\nmcp_servers:" in existing
+    if has_mcp and "burp:" in existing:
+        print("  = Hermes: burp already in mcp_servers (no change).")
+        return
+    if has_mcp:
+        print(f"  ℹ Hermes: {path} already has mcp_servers — add this under it manually:")
+        print("\n".join("        " + l for l in body[1:]))
+        return
+    print(f"  → Hermes: append mcp_servers.burp to {path}")
+    if dry:
+        print("      [dry-run]" + block.replace("\n", "\n        "))
+        return
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    backup(path)
+    with open(path, "a", encoding="utf-8") as f:
+        if existing and not existing.endswith("\n"):
+            f.write("\n")
+        f.write(block)
+    print("  ✓ Hermes burp MCP written.")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--opencode", action="store_true")
+    ap.add_argument("--codex", action="store_true")
+    ap.add_argument("--hermes", action="store_true")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--command")
+    ap.add_argument("--arg", action="append", default=[])
+    a = ap.parse_args()
+
+    if a.command:
+        cmd, args, env = a.command, a.arg, {}
+    else:
+        found = discover_burp()
+        if not found:
+            print("✗ Could not find a 'burp' MCP server in ~/.claude.json.")
+            print("  Pass it explicitly, e.g.:")
+            print("    --command java --arg -jar --arg ~/.BurpSuite/mcp-proxy/mcp-proxy-all.jar --arg --sse-url --arg http://127.0.0.1:9876")
+            return 1
+        cmd, args, env = found
+
+    print(f"Burp MCP source: {cmd} {' '.join(args)}{'  (dry-run)' if a.dry_run else ''}")
+    if not (a.opencode or a.codex or a.hermes):
+        print("Nothing to do — pass --opencode / --codex / --hermes.")
+        return 0
+    if a.opencode:
+        write_opencode(cmd, args, env, a.dry_run)
+    if a.codex:
+        write_codex(cmd, args, env, a.dry_run)
+    if a.hermes:
+        write_hermes(cmd, args, env, a.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/hunt-ntlm-info/SKILL.md
+++ b/skills/hunt-ntlm-info/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hunt-ntlm-info
-description: Hunt NTLM/Negotiate information disclosure on internet-reachable IIS/SharePoint/Exchange. Anonymous NTLM Type-2 challenge capture leaks NetBIOS domain, internal DNS forest, computer name, AD timestamp via AV_PAIRS structure. Default Windows-installer hostnames (WIN-XXXXXXXXXXX pattern) signal lazy provisioning. Use when target advertises `WWW-Authenticate: NTLM` or `Negotiate` headers anonymously.
+description: "Hunt NTLM/Negotiate information disclosure on internet-reachable IIS/SharePoint/Exchange. Anonymous NTLM Type-2 challenge capture leaks NetBIOS domain, internal DNS forest, computer name, AD timestamp via AV_PAIRS structure. Default Windows-installer hostnames (WIN-XXXXXXXXXXX pattern) signal lazy provisioning. Use when target advertises `WWW-Authenticate: NTLM` or `Negotiate` headers anonymously."
 sources: github, authorized-engagement
 report_count: 1
 ---


### PR DESCRIPTION
Makes the 71 skills run on **OpenCode, Codex, and Hermes Agent** from one source — not just Claude Code. Verified end-to-end on each (skills load **and** live Burp MCP connects), per a strict "test every harness + MCP" bar.

## Verified on this machine
| Harness | Skills | Burp MCP |
|---|---|---|
| **OpenCode** 1.15.11 | ✅ 48 hunt-* loaded (debug logs) | ✅ `opencode mcp list` → `burp connected` |
| **Hermes** v0.14.0 | ✅ enabled in `hermes skills list` | ✅ `hermes mcp test burp` → **24 tools** |
| **Codex** 0.137.0 | ✅ 0 skill-load errors | ✅ session `mcp_servers="burp, codex_apps"`, model OK |

## What's added
- **`install.sh`** flags: `--agents` (→ `~/.agents/skills`, read by Codex + OpenCode), `--hermes` (→ `~/.hermes/skills`), `--all`, `--burp-mcp`. Default behavior unchanged. (Also fixed a `set -e` footgun that would've aborted the default install.)
- **`scripts/setup_harness_mcp.py`** — translates your **existing** Burp MCP (from `~/.claude.json`) into OpenCode JSON / Codex TOML / Hermes YAML, backing up each first. `--dry-run` supported.
- **`docs/multi-harness.md`** — compatibility matrix, per-harness install, MCP snippets, caveats.

## Two real bugs the live Codex test caught (Codex enforces strict YAML + a 1024-char description cap)
- **`hunt-ntlm-info`** had an unquoted `` `WWW-Authenticate: NTLM` `` in its description — the `: ` broke strict YAML. Claude/OpenCode/Hermes tolerated it; Codex rejected it. **Fixed** (quoted).
- **3 aggregator skills** exceed 1024 chars → `install.sh --agents` now **auto-truncates them in the `~/.agents` (Codex) copy only**; `~/.claude`/`~/.hermes` keep full descriptions (incl. non-English triggers). Repo descriptions untouched.
- **`lint_skills.py`** hardened: YAML-safety check (catches the unquoted-colon class) + Codex-limit note.

## Boundary (by design)
Slash commands (`/hunt`…), the plugin marketplace, and `hunt-dispatch` are Claude-Code-only — other harnesses get the skill knowledge + Burp MCP, not the `/hunt` engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)