### PR TITLE
fix: add lastUpdated to marketplace.json + CBH_SKILLS_DIR env var support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "elementalsouls",
+  "lastUpdated": "2026-07-18T00:00:00Z",
   "owner": {
     "name": "Sachin Sharma",
     "url": "https://github.com/elementalsouls"

--- a/engine/skill_map.py
+++ b/engine/skill_map.py
@@ -14,7 +14,7 @@ Active testing is curl-first; Burp MCP is optional (only where noted — OOB/bli
 """
 import os
 
-SKILLS_DIR = os.path.expanduser("~/.claude/skills")
+SKILLS_DIR = os.environ.get("CBH_SKILLS_DIR", os.path.expanduser("~/.claude/skills"))
 
 # attack class -> hunt skill(s) in the bundle
 CLASS_SKILL = {


### PR DESCRIPTION
## Fix 1: Add missing `lastUpdated` field to marketplace.json

Claude Code marketplace parser expects `lastUpdated` as a string field at the root of marketplace.json. When absent, it parses as null which causes:

```
Marketplace configuration file is corrupted: elementalsouls.lastUpdated:
Invalid input: expected string, received null
```

This prevents `claude plugins marketplace add` and `claude plugins install` from working.

## Fix 2: Support `CBH_SKILLS_DIR` env var in engine/skill_map.py

Plugin skills live in `~/.claude/plugins/cache/elementalsouls/claude-bughunter/.../skills/` not `~/.claude/skills`. The engine cannot find skills when CBH is installed as a Claude Code plugin.

`CBH_SKILLS_DIR` allows the engine to locate skills in the plugin cache directory. Falls back to `~/.claude/skills` for standalone/non-plugin usage.

## Verification

- marketplace.json: Valid JSON, lastUpdated set to ISO 8601 timestamp
- skill_map.py: `os.environ.get("CBH_SKILLS_DIR", os.path.expanduser("~/.claude/skills"))`
