### PR TITLE
feat(install): add native Windows PowerShell installers (no WSL)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 
 # Executable text MUST be LF regardless of platform.
 *.sh   text eol=lf
+*.ps1  text eol=lf
 *.py   text eol=lf
 *.bash text eol=lf
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ versioning is loosely [SemVer](https://semver.org/) at the bundle level.
 ## [Unreleased]
 
 ### Added
+- **Native Windows install ** — every `.sh` installer now has a PowerShell
+  counterpart: `scripts/install.ps1`, `scripts/install-community-skills.ps1`, `scripts/hunt.ps1`.
+  Same behavior, same flags (hyphen-style: `-All`, `-Agents`, `-Hermes`, `-BurpMcp`, `-NoProfile`,
+  `-Uninstall`), same manifest-driven uninstall. `hunt.ps1` is dot-sourced from the PowerShell
+  `$PROFILE` (the Windows equivalent of the `.zshrc`/`.bashrc` `source` line). `.gitattributes`
+  now pins `*.ps1` to LF alongside `*.sh`/`*.py`. Docs (README, INSTALL, USAGE, multi-harness,
+  SECURITY, index, credits) updated to show both paths. macOS/Linux unchanged.
 - **Skill library expanded 71 → 82** — 9 new hunt skills (`hunt-jwt-crypto`, `hunt-rag-vector`,
   `hunt-shadow-api`, `hunt-captcha-bypass`, `hunt-clickjacking`, `hunt-html-injection`,
   `hunt-forgot-password`, `hunt-exceptional-conditions`, `ios-redteam-pipeline`) plus `hunt-spa-api`

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@ Step-by-step setup for the Claude-BugHunter skill bundle.
 ## Prerequisites
 
 - **Claude Code** — install from https://claude.ai/download
-- **macOS or Linux** — most steps are macOS-flavored; Linux users adjust paths
+- **macOS, Linux, or Windows** — macOS/Linux use the bash installers; Windows uses the native PowerShell installers
 - **Python 3.9+** — for the `cbh` CLI runner
 
 ### Optional (recommended but not required)
@@ -28,8 +28,14 @@ All three modes are first-class supported. The skills + CLI work identically acr
 ## Step 1 — Clone this repo
 
 ```bash
-mkdir -p ~/security-research
-cd ~/security-research
+# macOS / Linux
+mkdir -p ~/security-research && cd ~/security-research
+
+# Windows (PowerShell)
+New-Item -ItemType Directory -Force -Path "$HOME\security-research"
+cd "$HOME\security-research"
+
+# both
 git clone https://github.com/elementalsouls/Claude-BugHunter.git
 cd Claude-BugHunter
 ```
@@ -37,19 +43,24 @@ cd Claude-BugHunter
 ## Step 2 — Run the installer
 
 ```bash
+# macOS / Linux
 bash scripts/install.sh
+
+# Windows (PowerShell)
+pwsh ./scripts/install.ps1
 ```
 
-> On Windows/WSL, the repo ships a `.gitattributes` that forces LF line endings, so a
-> **fresh clone installs cleanly**. If you have an **existing** checkout that already
-> picked up CRLF (cloned before this `.gitattributes`), normalize it once with
+> The repo ships a `.gitattributes` that forces LF line endings on shell and
+> PowerShell scripts, so a **fresh clone installs cleanly** on every platform. If you
+> have an **existing** checkout that already picked up CRLF (cloned before this
+> `.gitattributes`), normalize it once with
 > `git add --renormalize . && git checkout .` (or just re-clone) — a CRLF-corrupted
-> shell script aborts with a `syntax error` and cannot fix itself.
+> script aborts with a `syntax error` and cannot fix itself.
 
 This copies:
-- All 82 skills → `~/.claude/skills/`
+- All 82 skills → `~/.claude/skills/` (macOS/Linux) or `%USERPROFILE%\.claude\skills\` (Windows)
 - All 15 slash commands → `~/.claude/commands/`
-- The `hunt` shell command → `~/.claude/scripts/hunt.sh` (sourced from your `.zshrc` or `.bashrc` automatically)
+- The `hunt` scaffolder → `~/.claude/scripts/hunt.sh` (sourced from your `.zshrc`/`.bashrc`) on macOS/Linux, or `~\.claude\scripts\hunt.ps1` (dot-sourced from your PowerShell `$PROFILE`) on Windows
 
 Existing skills with the same name are backed up to `~/.claude/install-backups/<timestamp>/` — **outside** the skills/commands directories, so backups never load as duplicate skills. Re-runs are non-destructive.
 
@@ -58,10 +69,19 @@ Existing skills with the same name are backed up to `~/.claude/install-backups/<
 The skills are plain Agent Skills, so they also run outside Claude Code:
 
 ```bash
+# macOS / Linux
 ./scripts/install.sh --all          # also installs to ~/.agents/skills (Codex + OpenCode) and ~/.hermes/skills (Hermes)
 ./scripts/install.sh --agents       # just Codex + OpenCode
 ./scripts/install.sh --hermes       # just Hermes
 ./scripts/install.sh --agents --burp-mcp   # also wire your Burp MCP into those harnesses
+```
+
+```powershell
+# Windows (PowerShell)
+pwsh ./scripts/install.ps1 -All          # Codex + OpenCode + Hermes
+pwsh ./scripts/install.ps1 -Agents       # just Codex + OpenCode
+pwsh ./scripts/install.ps1 -Hermes       # just Hermes
+pwsh ./scripts/install.ps1 -Agents -BurpMcp   # also wire your Burp MCP into those harnesses
 ```
 
 Slash commands, the plugin marketplace, and the `/hunt` engine are Claude-Code-only; other harnesses get the skill knowledge + Burp MCP. Full details and per-harness MCP snippets: [`docs/multi-harness.md`](docs/multi-harness.md).
@@ -78,7 +98,13 @@ In Burp Suite:
 In your terminal:
 
 ```bash
+# macOS / Linux
 claude mcp add burp -s user -- java -jar ~/.BurpSuite/mcp-proxy/mcp-proxy-all.jar
+```
+
+```powershell
+# Windows (PowerShell)
+claude mcp add burp -s user -- java -jar "$HOME\.BurpSuite\mcp-proxy\mcp-proxy-all.jar"
 ```
 
 Verify in a fresh `claude` session:
@@ -94,11 +120,20 @@ You should see `burp · ✓ connected`.
 The bundle ships a frozen snapshot of shuvonsec's skills. To pull the latest from upstream and re-bundle:
 
 ```bash
+# macOS / Linux
 chmod +x scripts/install-community-skills.sh
 ./scripts/install-community-skills.sh
+
+# Windows (PowerShell)
+pwsh ./scripts/install-community-skills.ps1
 ```
 
 This clones `shuvonsec/claude-bug-bounty` into `~/security-research/community-skills/` and runs its installer. Useful when you want fresher hunt patterns; not needed for first-time setup.
+
+> **Windows note:** the upstream `shuvonsec/claude-bug-bounty` ships its own bash
+> installer. `install-community-skills.ps1` runs it through Git-for-Windows `bash`
+> if available, and skips it (with a notice) otherwise. Install Git for Windows
+> (https://git-scm.com).
 
 ## Step 5 — (Optional) Set up the skill regenerator
 
@@ -180,7 +215,11 @@ If all three smoke tests pass, you're set up.
 Delete the test target:
 
 ```bash
+# macOS / Linux
 rm -rf ~/Targets/acme-test
+
+# Windows (PowerShell)
+Remove-Item -Recurse -Force "$HOME\Targets\acme-test"
 ```
 
 Then go find a real program and put it to work. See [USAGE.md](USAGE.md) for the full workflow walkthrough.
@@ -190,10 +229,11 @@ Then go find a real program and put it to work. See [USAGE.md](USAGE.md) for the
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `/mcp` doesn't show burp | Burp Suite not running, or extension not loaded | Re-open Burp, confirm Extensions tab shows MCP Server with "Loaded" checked |
-| `hunt: command not found` | Shell didn't pick up the `source` line | Restart your terminal, or `source ~/.zshrc` |
+| `hunt: command not found` (macOS/Linux) | Shell didn't pick up the `source` line | Restart your terminal, or `source ~/.zshrc` |
+| `hunt` not recognized (Windows) | PowerShell didn't load the profile | Open a new PowerShell window, or `. $PROFILE`; check execution policy is `RemoteSigned` or less restrictive (`Get-ExecutionPolicy -List`) |
 | Skills don't trigger as expected | Description-field keyword mismatch | Mention the bug class explicitly in your prompt (e.g., "I'm testing IDOR on this endpoint") |
 | `burp - get_proxy_history_regex` returns empty | Burp's proxy history is empty for that target | Browse the target through Burp first to populate history |
-| Python build errors during step 5 | Using system Python 3.9 | Use Homebrew Python 3.12 explicitly: `/opt/homebrew/bin/python3.12 -m venv .venv` |
+| Python build errors during step 5 | Using system Python 3.9 | macOS: use Homebrew Python 3.12 (`/opt/homebrew/bin/python3.12 -m venv .venv`); Windows: use the official python.org installer or `py -3.12 -m venv .venv` |
 
 ## Uninstall
 
@@ -202,10 +242,14 @@ The installer writes a manifest of exactly what it placed (under
 **only** that footprint — with:
 
 ```bash
+# macOS / Linux
 bash scripts/install.sh --uninstall
+
+# Windows (PowerShell)
+pwsh ./scripts/install.ps1 -Uninstall
 ```
 
-This removes the bundle's skills, slash commands, the `hunt.sh` script, and its
+This removes the bundle's skills, slash commands, the `hunt.sh`/`hunt.ps1` script, and its
 shell-rc source line. Skills you also installed from the **sister bundle**
 [Claude-OSINT](https://github.com/elementalsouls/Claude-OSINT) — `offensive-osint`
 and `osint-methodology` — are **kept** if Claude-OSINT's manifest still claims them,

--- a/README.md
+++ b/README.md
@@ -50,8 +50,17 @@ All 82 skills + 15 commands load namespaced under `claude-bughunter:` and update
 ```bash
 git clone https://github.com/elementalsouls/Claude-BugHunter.git
 cd Claude-BugHunter
-bash scripts/install.sh        # copies skills + commands into ~/.claude/
 ```
+
+```bash
+# macOS / Linux
+bash scripts/install.sh
+
+# Windows (PowerShell)
+pwsh ./scripts/install.ps1
+```
+
+Both copy the skills + commands into `~/.claude/` (macOS/Linux) or `%USERPROFILE%\.claude\` (Windows) and wire the `hunt` engagement scaffolder.
 
 **What each install path gives you:**
 
@@ -92,10 +101,14 @@ That's it. Open Claude Code and describe what you're testing in plain English �
 The skills are plain [Agent Skills](https://docs.claude.com/en/docs/claude-code/skills) — the same `SKILL.md` format that **Claude Code · OpenCode · OpenAI Codex CLI · Hermes Agent** all load. One command installs them everywhere:
 
 ```bash
+# macOS / Linux
 bash scripts/install.sh --all --burp-mcp
+
+# Windows (PowerShell)
+pwsh ./scripts/install.ps1 -All -BurpMcp
 ```
 
-`--all` copies the skills to every harness's path (`~/.claude/skills`, `~/.agents/skills`, `~/.hermes/skills`); `--burp-mcp` wires the Burp MCP server into each. The full *knowledge* layer ports to all four — the slash commands and `/hunt` engine stay Claude-Code-only by design.
+`--all` (`-All`) copies the skills to every harness's path (`~/.claude/skills`, `~/.agents/skills`, `~/.hermes/skills`); `--burp-mcp` (`-BurpMcp`) wires the Burp MCP server into each. The full *knowledge* layer ports to all four — the slash commands and `/hunt` engine stay Claude-Code-only by design.
 
 → [Multi-harness guide](docs/multi-harness.md)
 
@@ -261,7 +274,7 @@ Operational tradecraft accumulated across bug-bounty engagements and authorized 
 
 **Author:** [ElementalSoul](https://github.com/elementalsouls) · GenAI Security Research
 
-**Sister project:** [Claude-OSINT](https://github.com/elementalsouls/Claude-OSINT) — paired skills for the recon phase that this bundle picks up after. Its two recon skills (`offensive-osint`, `osint-methodology`) are **canonically maintained here** and re-exported there, so the two are byte-identical. **Installing both is safe:** each bundle's `install.sh` records a manifest, the script skips re-copying an identical skill, and `--uninstall` keeps any skill the other bundle still owns — uninstalling one never breaks the other.
+**Sister project:** [Claude-OSINT](https://github.com/elementalsouls/Claude-OSINT) — paired skills for the recon phase that this bundle picks up after. Its two recon skills (`offensive-osint`, `osint-methodology`) are **canonically maintained here** and re-exported there, so the two are byte-identical. **Installing both is safe:** each bundle's installer (`install.sh` on macOS/Linux, `install.ps1` on Windows) records a manifest, the script skips re-copying an identical skill, and `--uninstall` keeps any skill the other bundle still owns — uninstalling one never breaks the other.
 
 **Vendored foundation:** [shuvonsec/claude-bug-bounty](https://github.com/shuvonsec/claude-bug-bounty) — methodology, validation, reporting, payload library (8 of 82 skills + 15 slash commands)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,8 +55,8 @@ You are installing 71 `SKILL.md` files plus shell and Python helpers into your A
 **What we do on our side:**
 
 - **CI gate on every skill change** — [`.github/workflows/skill-lint.yml`](.github/workflows/skill-lint.yml) runs `scripts/lint_skills.py` on each PR: it validates `SKILL.md` structure against `CONTRIBUTING.md` and scans for leaked secrets and client/engagement identifiers.
-- **Pinned, reviewable provenance** — installing via the **plugin marketplace** pins each release to a specific commit SHA and runs Anthropic's automated screening. From a clone you can pin yourself: `git checkout <tag-or-commit>` before `bash scripts/install.sh`.
-- **No network calls at install time** — `install.sh` only copies local files and (unless `--no-shell`) appends one `source` line to your shell rc, which it prints back to you.
+- **Pinned, reviewable provenance** — installing via the **plugin marketplace** pins each release to a specific commit SHA and runs Anthropic's automated screening. From a clone you can pin yourself: `git checkout <tag-or-commit>` before running the installer (`bash scripts/install.sh` on macOS/Linux, `pwsh ./scripts/install.ps1` on Windows).
+- **No network calls at install time** — the installer only copies local files and (unless `--no-shell`/`-NoProfile`) appends one `source`/dot-source line to your shell rc / PowerShell profile, which it prints back to you.
 
 **What this does NOT prove — read this:**
 
@@ -71,7 +71,7 @@ If you find a skill or script in this repo that could be abused, see **Reporting
 If you discover a security issue in **this repository itself** (not in a target you're hunting):
 
 - **Skill content** that you believe could enable abuse against unauthorized targets without commensurate defensive value: open a GitHub issue with the `security` label, or contact the author at the address listed on the [GitHub profile](https://github.com/elementalsouls).
-- **Vulnerabilities in installer scripts** (`scripts/install.sh`, `scripts/install-community-skills.sh`, `scripts/hunt.sh`): same channels.
+- **Vulnerabilities in installer scripts** (`scripts/install.sh`, `scripts/install-community-skills.sh`, `scripts/hunt.sh` on macOS/Linux; their `scripts/*.ps1` counterparts on Windows): same channels.
 - **Sensitive content accidentally shipped** (engagement-specific data, real account UIDs, real bounty amounts): flag immediately — these will be sanitized in a follow-up commit.
 
 Please **do not** post issues that include unauthorized exploitation evidence against third-party targets.

--- a/USAGE.md
+++ b/USAGE.md
@@ -20,7 +20,7 @@ You don't "learn" the bundle. You install it once, then describe what you're tes
 
 ### What you DO need before starting
 
-1. **A laptop running macOS or Linux** (Windows users: WSL2 Ubuntu works).
+1. **A laptop running macOS, Linux, or Windows** — macOS/Linux use bash, Windows uses native PowerShell.
 2. **Claude Code installed** (from https://claude.ai/download) — this is the CLI app, not Claude.ai in your browser.
 3. **A Claude paid plan** (Pro/Team/Max) or an Anthropic API key with credit. Free Claude.ai doesn't include Claude Code.
 4. **The terminal app open** and the willingness to copy-paste 3 commands.
@@ -32,23 +32,42 @@ You don't "learn" the bundle. You install it once, then describe what you're tes
 - ❌ You don't need to know Burp Suite. It's optional. Skills work with curl + browser.
 - ❌ You don't need a bug bounty account yet. You can practice on OWASP Juice Shop first.
 - ❌ You don't need to read all 82 skills. They auto-load when relevant.
-- ❌ You don't need Python beyond `python3 --version` working.
+- ❌ You don't need Python beyond `python --version` working (run `python3 --version` on macOS/Linux).
 
 ### Your first 30 minutes
 
-Open your terminal. Copy-paste this entire block:
+Open your terminal. Copy-paste the block for your platform:
 
 ```bash
+# macOS / Linux
 # 1. Get the bundle
 mkdir -p ~/security-research && cd ~/security-research
 git clone https://github.com/elementalsouls/Claude-BugHunter.git
 cd Claude-BugHunter
 
 # 2. Install (copies 82 skills + 15 commands into Claude Code)
-./scripts/install.sh
+bash scripts/install.sh
 
 # 3. Reload your shell so the 'hunt' command becomes available
 source ~/.zshrc 2>/dev/null || source ~/.bashrc
+
+# 4. Verify — running 'hunt' with no args should print usage info
+hunt
+```
+
+```powershell
+# Windows (PowerShell)
+# 1. Get the bundle
+New-Item -ItemType Directory -Force -Path "$HOME\security-research"
+cd "$HOME\security-research"
+git clone https://github.com/elementalsouls/Claude-BugHunter.git
+cd Claude-BugHunter
+
+# 2. Install (copies 82 skills + 15 commands into Claude Code)
+pwsh ./scripts/install.ps1
+
+# 3. Reload your profile so the 'hunt' command becomes available
+. $PROFILE
 
 # 4. Verify — running 'hunt' with no args should print usage info
 hunt
@@ -61,7 +80,7 @@ Creates a new engagement folder at $HUNT_BASE/<target-name>
 Default $HUNT_BASE is /Users/you/Targets
 ```
 
-If it says `command not found` instead, restart your terminal entirely and try again. Still failing? Go to [INSTALL.md → Troubleshooting](INSTALL.md#troubleshooting).
+If it says `command not found` (macOS/Linux) or `not recognized` (Windows), restart your terminal entirely and try again. Still failing? Go to [INSTALL.md → Troubleshooting](INSTALL.md#troubleshooting).
 
 ### Pick a practice target
 
@@ -261,7 +280,7 @@ Required for external red-team work where targets are full enterprise estates ra
 | Tool | Purpose | Setup |
 |---|---|---|
 | **Burp MCP** | Claude reads/replays HTTP traffic directly from Burp's proxy history — eliminates manual paste-curl-into-chat | Burp Suite + MCP Server extension (port 9876) → `claude mcp add burp -s user -- java -jar ~/.BurpSuite/mcp-proxy/mcp-proxy-all.jar` |
-| **`hunt <target>` shell command** | Scaffolds `~/Targets/<name>/` with CLAUDE.md, scope.md, findings/, evidence/, submissions.txt | `source ~/.claude/scripts/hunt.sh` in your `.zshrc` |
+| **`hunt <target>` command** | Scaffolds `~/Targets/<name>/` with CLAUDE.md, scope.md, findings/, evidence/, submissions.txt | macOS/Linux: `source ~/.claude/scripts/hunt.sh` in `.zshrc` · Windows: `. "$HOME\.claude\scripts\hunt.ps1"` in `$PROFILE` |
 | **Anthropic API (separate from Claude Max)** | Powers `public-skills-builder` for periodic skill regeneration | `console.anthropic.com/billing` → API key → `export ANTHROPIC_API_KEY=...` |
 | **HackerOne API** | Pulls disclosed reports for the skill builder | `hackerone.com/settings/api_token` → `H1_API_KEY=username:token` in `.env` |
 
@@ -378,9 +397,9 @@ Cross-reference this UUID in any chained submissions you file later.
 If another pentester wants to replicate this stack, the install steps are in [INSTALL.md](INSTALL.md). The short version:
 
 1. Clone this repo
-2. Run `./scripts/install.sh` (installs all 82 skills, 15 commands, and hunt scaffold in one step)
+2. Run the installer — `bash scripts/install.sh` (macOS/Linux) or `pwsh ./scripts/install.ps1` (Windows) — installs all 82 skills, 15 commands, and the `hunt` scaffold in one step
 3. Set up Burp MCP (BApp Store extension + `claude mcp add burp ...`)
-4. (Optional) Refresh upstream snapshots via `./scripts/install-community-skills.sh`
+4. (Optional) Refresh upstream snapshots via `./scripts/install-community-skills.sh` (macOS/Linux) or `pwsh ./scripts/install-community-skills.ps1` (Windows)
 5. (Optional) Set up the skill regenerator with Anthropic + H1 API keys
 
 Total setup time: ~10 minutes including Burp MCP.

--- a/docs/credits.md
+++ b/docs/credits.md
@@ -78,8 +78,8 @@ Built from authorized red-team engagements (enterprise targets including on-prem
 
 ### Tooling and docs
 
-- **`hunt <target>` shell command** — Engagement-folder scaffolding: creates `~/Targets/<name>/` with `CLAUDE.md`, `scope.md`, `findings/`, `evidence/`, `submissions.txt`, `notes.md`, and a sensible `.gitignore` for engagement artifacts.
-- **Bundle packaging** — Single-step installer (`scripts/install.sh`) that copies all 82 skills, 15 commands, and the hunt scaffold into `~/.claude/`.
+- **`hunt <target>` command** — Engagement-folder scaffolding: creates `~/Targets/<name>/` with `CLAUDE.md`, `scope.md`, `findings/`, `evidence/`, `submissions.txt`, `notes.md`, and a sensible `.gitignore` for engagement artifacts. Ships as `scripts/hunt.sh` (bash) and `scripts/hunt.ps1` (PowerShell).
+- **Bundle packaging** — Single-step installer that copies all 82 skills, 15 commands, and the hunt scaffold into `~/.claude/`: `scripts/install.sh` (macOS/Linux) and `scripts/install.ps1` (Windows/PowerShell).
 - **`assets/banner-v2.svg`** — Hand-coded SVG banner.
 - **Documentation** — `README.md`, `INSTALL.md`, `USAGE.md`, `CONTRIBUTING.md`, `docs/architecture.md`, this credits file.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,10 +35,17 @@ platform CVE chains, and the hygiene, and it stays in scope.
 ## Quickstart
 
 ```bash
-# Clone and install into ~/.claude/
+# macOS / Linux — clone and install into ~/.claude/
 git clone https://github.com/elementalsouls/Claude-BugHunter.git
 cd Claude-BugHunter
 bash scripts/install.sh
+```
+
+```powershell
+# Windows (PowerShell)
+git clone https://github.com/elementalsouls/Claude-BugHunter.git
+cd Claude-BugHunter
+pwsh ./scripts/install.ps1
 ```
 
 Then open Claude Code and describe what you're testing in plain English —

--- a/docs/multi-harness.md
+++ b/docs/multi-harness.md
@@ -26,29 +26,51 @@ The 82 skills are plain **Agent Skills** (`SKILL.md` = `name` + `description` fr
 One command installs the skills to every harness's path (copy install; existing skills are backed up outside the loading path):
 
 ```bash
+# macOS / Linux
 git clone https://github.com/elementalsouls/Claude-BugHunter.git
 cd Claude-BugHunter
 bash scripts/install.sh --all          # Claude + ~/.agents/skills (Codex/OpenCode) + ~/.hermes/skills
 ```
 
+```powershell
+# Windows (PowerShell)
+git clone https://github.com/elementalsouls/Claude-BugHunter.git
+cd Claude-BugHunter
+pwsh ./scripts/install.ps1 -All         # Claude + ~/.agents/skills (Codex/OpenCode) + ~/.hermes/skills
+```
+
 Pick specific harnesses instead:
 
 ```bash
+# macOS / Linux
 bash scripts/install.sh                 # Claude Code only (default)
 bash scripts/install.sh --agents        # + Codex & OpenCode (~/.agents/skills)
 bash scripts/install.sh --hermes        # + Hermes Agent (~/.hermes/skills)
 ```
 
-- **OpenCode** already reads `~/.claude/skills/`, so the plain `install.sh` (no flags) is enough for OpenCode — you don't need `--agents` for it. `--agents` exists mainly for **Codex** (which reads only `~/.agents/skills/`).
-  - *Caveat (verified):* OpenCode reads **both** `~/.claude/skills/` and `~/.agents/skills/`. If both are populated (e.g. you ran `--all` for Codex too), OpenCode logs harmless `duplicate skill name` warnings and loads one copy — all 82 skills still work. Only populate `~/.agents/skills/` if you actually use Codex.
-- **Codex is the strict parser** (verified by testing): it hard-rejects descriptions > 1024 chars and invalid YAML, where Claude/OpenCode/Hermes are lenient. So `install.sh` **auto-truncates** any description > 1024 to ≤1024 **only in the `~/.agents/skills` (Codex) copy** — your `~/.claude` and `~/.hermes` copies keep the full descriptions (incl. non-English trigger words). The install logs which were truncated (today: the 3 aggregator router skills). `--normalize-frontmatter` additionally strips the non-standard `sources:`/`report_count:` keys (optional — Codex tolerates them).
+```powershell
+# Windows (PowerShell)
+pwsh ./scripts/install.ps1              # Claude Code only (default)
+pwsh ./scripts/install.ps1 -Agents      # + Codex & OpenCode (~/.agents/skills)
+pwsh ./scripts/install.ps1 -Hermes      # + Hermes Agent (~/.hermes/skills)
+```
+
+- **OpenCode** already reads `~/.claude/skills/`, so the plain installer (no flags) is enough for OpenCode — you don't need `--agents`/`-Agents` for it. That flag exists mainly for **Codex** (which reads only `~/.agents/skills/`).
+  - *Caveat (verified):* OpenCode reads **both** `~/.claude/skills/` and `~/.agents/skills/`. If both are populated (e.g. you ran `--all`/`-All` for Codex too), OpenCode logs harmless `duplicate skill name` warnings and loads one copy — all 82 skills still work. Only populate `~/.agents/skills/` if you actually use Codex.
+- **Codex is the strict parser** (verified by testing): it hard-rejects descriptions > 1024 chars and invalid YAML, where Claude/OpenCode/Hermes are lenient. So the installer **auto-truncates** any description > 1024 to ≤1024 **only in the `~/.agents/skills` (Codex) copy** — your `~/.claude` and `~/.hermes` copies keep the full descriptions (incl. non-English trigger words). The install logs which were truncated (today: the 3 aggregator router skills). `--normalize-frontmatter` (`-NormalizeFrontmatter`) additionally strips the non-standard `sources:`/`report_count:` keys (optional — Codex tolerates them).
 
 ## Burp MCP on other harnesses
 
-Your Burp MCP is a stdio command, so it translates 1:1. `install.sh --burp-mcp` (with a harness flag) wires it automatically by translating your **existing** Claude Code Burp definition (from `~/.claude.json`) — it backs up each config first:
+Your Burp MCP is a stdio command, so it translates 1:1. `--burp-mcp` (`-BurpMcp`, with a harness flag) wires it automatically by translating your **existing** Claude Code Burp definition (from `~/.claude.json`) — it backs up each config first:
 
 ```bash
+# macOS / Linux
 bash scripts/install.sh --agents --burp-mcp     # writes OpenCode + Codex MCP config; prints Hermes guidance
+```
+
+```powershell
+# Windows (PowerShell)
+pwsh ./scripts/install.ps1 -Agents -BurpMcp      # writes OpenCode + Codex MCP config; prints Hermes guidance
 ```
 
 Or do it manually (replace the jar path / port with yours):

--- a/scripts/hunt.ps1
+++ b/scripts/hunt.ps1
@@ -1,0 +1,313 @@
+# =====================================================================
+# hunt — bug-bounty engagement scaffolding (Windows / PowerShell port)
+#
+# Native Windows port of scripts/hunt.sh. No WSL, no bash required.
+# Adds a `hunt` function that creates a per-target working folder under
+# $HOME\Targets\ with CLAUDE.md, scope.md, submissions tracker, findings
+# folder, evidence folder (gitignored), and notes scratchpad.
+#
+# Usage:
+#   hunt acme            # creates $HOME\Targets\acme\ with full template
+#   hunt                 # shows usage
+#
+# Customize HUNT_BASE in your environment to override the parent dir:
+#   $env:HUNT_BASE = "$HOME\security-research\Targets"
+#
+# Install: dot-source this file from your PowerShell profile ($PROFILE):
+#   . "$HOME\.claude\scripts\hunt.ps1"
+# =====================================================================
+
+function hunt {
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0)]
+        [string] $Target,
+
+        [Parameter(Position = 1)]
+        [string] $Manifest
+    )
+
+    # BOM-free UTF-8 writer (PS 5.1's Set-Content -Encoding UTF8 adds a BOM,
+    # which breaks some tools reading these files).
+    function Write-HuntFile([string] $Path, [string] $Content) {
+        $parent = Split-Path -Parent $Path
+        if ($parent -and -not (Test-Path -LiteralPath $parent)) {
+            New-Item -ItemType Directory -Force -Path $parent | Out-Null
+        }
+        $enc = New-Object System.Text.UTF8Encoding($false)
+        [System.IO.File]::WriteAllText($Path, $Content, $enc)
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Target)) {
+        Write-Host "Usage: hunt <target-name>"
+        Write-Host "Creates a new engagement folder at `$HUNT_BASE\<target-name>"
+        Write-Host "Default `$HUNT_BASE is $HOME\Targets"
+        $global:LASTEXITCODE = 1
+        return
+    }
+
+    $base = if ($env:HUNT_BASE) { $env:HUNT_BASE } else { Join-Path $HOME 'Targets' }
+    $dir  = Join-Path $base $Target
+
+    if (Test-Path -LiteralPath $dir -PathType Container) {
+        Write-Host "Target '$Target' already exists at $dir"
+        Write-Host "cd $dir to continue working on it."
+        return
+    }
+
+    New-Item -ItemType Directory -Force -Path (Join-Path $dir 'findings'), (Join-Path $dir 'evidence') | Out-Null
+
+    $today = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')
+
+    # ============== CLAUDE.md ==============
+    $claudeBody = @'
+**Platform:** [TBD — Bugcrowd / HackerOne / Intigriti / Immunefi / private]
+**Program URL:** [paste the program page URL here]
+
+## Quick context for Claude
+
+This folder is the working directory for a single bug-bounty engagement.
+Files in this folder:
+
+- `scope.md` — parsed scope, OOS list, focus areas, bounty bands
+- `findings/` — one markdown file per finding draft (naming: `finding-<NN>-<short-name>.md`)
+- `submissions.txt` — submission IDs tracker (used for chain cross-references)
+- `evidence/` — screenshots, HARs, raw transcripts (gitignored — never share)
+- `notes.md` — running notes, leads, dead ends, hypotheses
+
+## Workflow
+
+1. **Plan** — fill in `scope.md` from the program page. Use the `bb-methodology`
+   and `osint-methodology` skills. Note Focus Areas and Bounty bands.
+
+2. **Recon** — `offensive-osint`, `web2-recon`, and `bb-local-toolkit` for
+   discovery. Pipe Burp through every browser session for proxy history.
+
+3. **Hunt** — `web2-vuln-classes` (or per-class `hunt-*` skills if installed)
+   plus `security-arsenal` for payloads.
+
+4. **Validate** — run `/triage` on every lead BEFORE drafting a report.
+   Apply the 7-Question Gate from `triage-validation`.
+
+5. **Capture evidence** — `evidence-hygiene` BEFORE any screenshot.
+   Cookies / PII / HARs all redacted per protocol.
+
+6. **Report** — `report-writing` for the body template. `bugcrowd-reporting`
+   if filing on Bugcrowd (VRT search, severity request, OOS rebuttals).
+
+7. **Track** — append every submitted finding's UUID to `submissions.txt`
+   so chained reports can cross-reference each other.
+
+## Engagement-specific rules
+
+- All testing on accounts I own.
+- Stop immediately on encountering other-user PII; document and report.
+- No public disclosure until program explicitly approves.
+- Test-account email: `<your-bugcrowdninja-alias>@bugcrowdninja.com`
+- Burp proxy capturing through all browser sessions for this target.
+
+## Useful commands during the engagement
+
+- `/scope <asset>` — verify a specific asset is in scope
+- `/triage` — quick 7-Question Gate on a finding
+- `/validate` — full 4-gate finding validator
+- `/report` — draft a submission-ready report
+- `/remember` — log a finding to hunt memory
+'@
+    $claudeMd = "# Engagement: $Target`r`n`r`n**Target:** $Target`r`n**Started:** $today`r`n" + $claudeBody
+    Write-HuntFile (Join-Path $dir 'CLAUDE.md') $claudeMd
+
+    # ============== scope.md ==============
+    $scopeBody = @'
+
+> Parse this from the program page (Bugcrowd / HackerOne / etc.) before
+> doing any active testing. `/scope <asset>` can verify individual assets.
+
+## In scope
+
+- (paste in-scope asset list here)
+
+## Out of scope
+
+- (paste OOS list here, including any bug classes excluded by the program)
+
+## Focus areas
+
+- (paste Focus Areas / accepted impacts list — these are the highest-leverage targets)
+
+## Bounty bands
+
+| Severity | Band |
+|---|---|
+| P1 (Critical) | |
+| P2 (High) | |
+| P3 (Medium) | |
+| P4 (Low) | |
+| P5 (Info) | (often unrewarded) |
+
+## Engagement rules / safe harbor
+
+- (paste any researcher-conduct rules — testing-account requirements,
+  rate-limit caps, no-DoS clauses, KYC posture, contact email, etc.)
+
+## Account / testing setup
+
+- **Test account email:** (`alias@bugcrowdninja.com` if Bugcrowd)
+- **Test account uid:**
+- **Production vs QA:** (which environment is in scope, and any special access notes)
+- **Mobile builds:** (Android APK / iOS IPA download URLs if provided)
+- **Authentication notes:** (SSO, MFA enrollment status, etc.)
+
+## OOS clauses worth pre-empting in submissions
+
+> Note any OOS clauses that might be miscategorized against your findings.
+> Use this to draft `In-scope justification` paragraphs proactively.
+
+- (e.g., "Rate limiting on non-authentication endpoints" — applies to
+  non-auth endpoints only; verify_password / OTP / token-validate are auth)
+- (e.g., "User Enumeration with low-risk info" — applies only when info
+  enumerated is low-risk; real-name PII is NOT low-risk)
+'@
+    Write-HuntFile (Join-Path $dir 'scope.md') ("# Scope — $Target" + $scopeBody)
+
+    # ============== submissions.txt ==============
+    $subBody = @'
+#
+# Format (tab-separated):
+# <UUID>  <severity>  <VRT-or-class>  <one-line title>
+#
+# Use `/remember` after each submission to append the new ID and link
+# back to chained primitives.
+
+'@
+    Write-HuntFile (Join-Path $dir 'submissions.txt') ("# Submissions tracker — $Target" + "`r`n" + $subBody)
+
+    # ============== findings/README.md ==============
+    $findingsReadme = @'
+
+One markdown file per lead.
+
+## Naming
+
+`finding-<NN>-<short-name>.md`
+
+Examples:
+- `finding-01-graphql-apq-bypass.md`
+- `finding-02-verify-password-no-rate-limit.md`
+- `finding-03-update-password-no-stepup.md`
+
+## Per-finding template
+
+Each finding file should have:
+1. Status (lead / validated / drafted / submitted / triaged / paid / closed)
+2. The finding summary (use `triage-validation`'s 7-Question Gate format)
+3. Reproduction steps with exact requests/responses
+4. Evidence inventory (path to redacted screenshots in ../evidence/)
+5. Severity reasoning + VRT mapping (if Bugcrowd)
+6. Submission UUID (once filed)
+7. Triager dialogue / status updates
+'@
+    Write-HuntFile (Join-Path $dir 'findings\README.md') ("# Findings — $Target" + $findingsReadme)
+
+    # ============== notes.md ==============
+    $notesBody = @'
+
+> Running scratchpad. Leads, hypotheses, dead ends.
+
+## Leads to investigate
+
+
+## Hypotheses being tested
+
+
+## Dead ends (so I don't re-investigate)
+
+
+## Tooling / setup notes for this target
+
+'@
+    Write-HuntFile (Join-Path $dir 'notes.md') ("# Notes — $Target" + $notesBody)
+
+    # ============== .gitignore ==============
+    $gitignore = @'
+# Never commit raw evidence — contains live cookies, PII, HARs
+evidence/
+
+# Common artifact extensions
+*.har
+*.png
+*.jpg
+*.jpeg
+*.mp4
+*.mov
+
+# Local OS noise
+.DS_Store
+Thumbs.db
+
+# Secrets / config
+.env
+*.pem
+*.key
+'@
+    Write-HuntFile (Join-Path $dir '.gitignore') $gitignore
+
+    # ============== recon manifest ingestion (optional) ==============
+    # If `cbh recon <target>` produced a manifest, seed scope + notes from it.
+    # Resolve from: 2nd arg → $HUNT_MANIFEST → .\recon\<target>\manifest.json.
+    $manifestPath = $Manifest
+    if ([string]::IsNullOrWhiteSpace($manifestPath) -and $env:HUNT_MANIFEST) {
+        $manifestPath = $env:HUNT_MANIFEST
+    }
+    if ([string]::IsNullOrWhiteSpace($manifestPath)) {
+        $candidates = @(
+            (Join-Path (Get-Location) "recon\$Target\manifest.json"),
+            (Join-Path (Get-Location) "recon/$Target/manifest.json"),
+            (Join-Path $HOME "recon\$Target\manifest.json")
+        )
+        foreach ($c in $candidates) {
+            if (Test-Path -LiteralPath $c) { $manifestPath = (Resolve-Path -LiteralPath $c).Path; break }
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($manifestPath) -and (Test-Path -LiteralPath $manifestPath) -and (Get-Command python -ErrorAction SilentlyContinue)) {
+        $py = @'
+import json, sys
+try:
+    m = json.load(open(sys.argv[1], encoding="utf-8"))
+except Exception as e:
+    print(f"  (recon manifest present but unreadable: {e})"); sys.exit(0)
+d = sys.argv[2]
+hosts = [a["host"] for a in m.get("assets", []) if a.get("url")]
+ranked = m.get("ranked_surface", [])
+with open(d + "/scope.md", "a", encoding="utf-8") as f:
+    f.write("\n## Recon-seeded live hosts (from cbh manifest — VERIFY in-scope before testing)\n\n")
+    for h in hosts:
+        f.write(f"- {h}\n")
+with open(d + "/notes.md", "a", encoding="utf-8") as f:
+    f.write("\n## Ranked surface (from recon manifest)\n\n")
+    for r in ranked:
+        cls = ", ".join(r.get("bug_classes", [])) or "no class match"
+        f.write(f"- [{r.get('priority','?')}] {r.get('url') or r.get('host')} - {cls}\n")
+print(f"  ✓ Ingested recon manifest: {len(hosts)} live hosts -> scope.md, {len(ranked)} ranked -> notes.md")
+'@
+        try {
+            $py | python - $manifestPath $dir
+        } catch {
+            Write-Host "  (recon manifest present but ingestion failed: $($_.Exception.Message))"
+        }
+    }
+
+    # ============== confirmation ==============
+    Write-Host "Initialized $dir with CLAUDE.md and engagement template."
+    Write-Host "cd $dir to start hacking."
+    Write-Host ""
+    Write-Host "Files created:"
+    Write-Host "  CLAUDE.md           - Claude Code engagement context"
+    Write-Host "  scope.md            - parsed scope template (fill from program page)"
+    Write-Host "  submissions.txt     - submission UUID tracker"
+    Write-Host "  findings/README.md  - findings folder convention"
+    Write-Host "  notes.md            - running scratchpad"
+    Write-Host "  evidence/           - gitignored screenshot/HAR folder"
+    Write-Host "  .gitignore          - excludes evidence + common secret patterns"
+}

--- a/scripts/install-community-skills.ps1
+++ b/scripts/install-community-skills.ps1
@@ -1,0 +1,128 @@
+# =====================================================================
+# install-community-skills.ps1 — OPTIONAL: refresh vendored skills from upstream
+#
+# Native Windows port of install-community-skills.sh. No WSL, no bash.
+# Requires: git, Windows PowerShell 5.1+ or PowerShell 7+.
+#
+# Claude-BugHunter ships a frozen snapshot of shuvonsec's skills and
+# commands inside skills\ and commands\. The default install path is
+# install.ps1 -- running this script is NOT required for first-time setup.
+#
+# Use this script only when you want to pull the LATEST upstream content
+# (newer hunt-* patterns, updated VRT mappings, etc.) into your
+# ~\.claude\. It clones shuvonsec/claude-bug-bounty into
+# ~\security-research\community-skills\ and runs its installer.
+#
+# Note: this updates ~\.claude\ but does NOT update the bundled snapshot
+# in this repo's skills\ -- to refresh that, copy from ~\.claude\skills\
+# back into the repo manually after running this.
+#
+# Idempotent: safe to re-run.
+# =====================================================================
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$CommunityDir = Join-Path $HOME 'security-research\community-skills'
+if (-not (Test-Path -LiteralPath $CommunityDir)) {
+    New-Item -ItemType Directory -Force -Path $CommunityDir | Out-Null
+}
+
+# === shuvonsec/claude-bug-bounty (foundation) ===
+$repoDir = Join-Path $CommunityDir 'claude-bug-bounty'
+if (-not (Test-Path -LiteralPath $repoDir)) {
+    Write-Host "Cloning shuvonsec/claude-bug-bounty..."
+    & git clone --depth=1 https://github.com/shuvonsec/claude-bug-bounty.git $repoDir
+    if ($LASTEXITCODE -ne 0) { throw "git clone failed (exit $LASTEXITCODE)" }
+} else {
+    Write-Host "shuvonsec/claude-bug-bounty already cloned -- pulling latest"
+    Push-Location $repoDir
+    try {
+        & git pull --ff-only
+        # git pull failing (e.g. diverged) is non-fatal, matching `|| true` in the bash original.
+    } finally {
+        Pop-Location
+    }
+}
+
+# === Backup existing bug-bounty skill if it exists (avoid overwrite) ===
+$bbSkill = Join-Path $HOME '.claude\skills\bug-bounty'
+$bbMd = Join-Path $bbSkill 'SKILL.md'
+if ((Test-Path -LiteralPath $bbSkill -PathType Container)) {
+    if (Test-Path -LiteralPath $bbMd) {
+        $content = Get-Content -Raw -LiteralPath $bbMd -ErrorAction SilentlyContinue
+        if ($content -match 'Master workflow') {
+            Write-Host "+ shuvonsec bug-bounty already installed"
+        } else {
+            $stamp = (Get-Date).ToString('yyyyMMdd-HHmmss')
+            $backup = "$bbSkill.backup-$stamp"
+            Write-Host "Backing up existing custom bug-bounty skill to $backup"
+            Move-Item -LiteralPath $bbSkill -Destination $backup -Force
+        }
+    }
+}
+
+# === Run shuvonsec's installer (which copies skills + commands) ===
+Write-Host "Running shuvonsec installer..."
+Push-Location $repoDir
+try {
+    # shuvonsec's install.sh is a bash script. On Windows it runs under Git
+    # Bash if present (git for Windows ships it); otherwise it is skipped.
+    $shInstaller = Join-Path $repoDir 'install.sh'
+    $ran = $false
+    if (Test-Path -LiteralPath $shInstaller) {
+        # Prefer bash from Git for Windows; fall back to WSL if installed.
+        $bash = $null
+        foreach ($cand in @(
+            (Join-Path $env:ProgramFiles 'Git\bin\bash.exe'),
+            (Join-Path ${env:ProgramFiles(x86)} 'Git\bin\bash.exe'),
+            (Join-Path $env:LOCALAPPDATA 'Programs\Git\bin\bash.exe')
+        )) {
+            if (Test-Path -LiteralPath $cand) { $bash = $cand; break }
+        }
+        if (-not $bash) { $bash = (Get-Command bash -ErrorAction SilentlyContinue).Source }
+        if ($bash) {
+            # Pipe "n" to skip the optional interactive Burp MCP setup prompt
+            # (we handle Burp MCP setup separately in INSTALL.md).
+            'n' | & $bash "$shInstaller"
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "! shuvonsec installer reported errors -- check output above"
+                Write-Host "If everything still installed correctly, you can ignore."
+            }
+            $ran = $true
+        }
+    }
+    if (-not $ran) {
+        Write-Host "! shuvonsec/install.sh is a bash script and bash was not found."
+        Write-Host "  Install Git for Windows (https://git-scm.com) to get bash, then re-run."
+    }
+} finally {
+    Pop-Location
+}
+
+# === Summary ===
+Write-Host ''
+Write-Host '============================================'
+Write-Host '+ Community foundation installed'
+Write-Host '============================================'
+Write-Host ''
+Write-Host "Skills now in $(Join-Path $HOME '.claude\skills'):"
+if (Test-Path -LiteralPath (Join-Path $HOME '.claude\skills')) {
+    Get-ChildItem -LiteralPath (Join-Path $HOME '.claude\skills') -Directory |
+        Select-Object -ExpandProperty Name | Sort-Object
+}
+Write-Host ''
+Write-Host "Commands now in $(Join-Path $HOME '.claude\commands'):"
+if (Test-Path -LiteralPath (Join-Path $HOME '.claude\commands')) {
+    Get-ChildItem -LiteralPath (Join-Path $HOME '.claude\commands') -File -Filter *.md |
+        Select-Object -ExpandProperty Name | Sort-Object
+}
+Write-Host ''
+Write-Host 'Next steps:'
+Write-Host '  1. Run .\scripts\install.ps1 to add original skills + hunt command'
+Write-Host '  2. Set up Burp MCP integration (see INSTALL.md Step 3)'
+Write-Host '  3. (Optional) Install per-class hunt-* skills via shuvonsec/public-skills-builder'
+Write-Host ''
+Write-Host 'See INSTALL.md for the full setup walkthrough.'

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,401 @@
+# =====================================================================
+# install.ps1 — Install Claude-BugHunter bundle (Windows / PowerShell)
+#
+# Native Windows port of install.sh. No WSL, no bash required.
+# Requires: Windows PowerShell 5.1+ or PowerShell 7+.
+#
+# DEFAULT (no flags): installs into ~\.claude\ for Claude Code —
+#   - skills\*        -> ~\.claude\skills\
+#   - commands\*.md   -> ~\.claude\commands\
+#   - scripts\hunt.ps1 -> ~\.claude\scripts\hunt.ps1 + dot-sourced from
+#                         the PowerShell profile ($PROFILE) automatically
+#
+# MULTI-HARNESS FLAGS (skills only — the 82 SKILL.md files. Slash commands,
+# the plugin marketplace, and the /hunt engine are Claude-Code-specific and do
+# NOT port; other harnesses get the knowledge, not the orchestration):
+#   -Agents        force-copy skills -> ~\.agents\skills\  (Codex; OpenCode reads ~\.claude)
+#   -Hermes        force-copy skills -> ~\.hermes\skills\   (Hermes Agent)
+#   -All           DETECT installed harnesses and install to each: Claude always, ~\.agents
+#                  if Codex is present, ~\.hermes if Hermes is present. With -BurpMcp it
+#                  wires Burp only into the detected harnesses. (-Agents/-Hermes still
+#                  force a path regardless of detection.)
+#   -BurpMcp       wire your existing Burp MCP server into the selected harnesses'
+#                  configs (opt-in; backs up each config first; uses python)
+#   -NormalizeFrontmatter
+#                  strip non-standard keys (sources/report_count) from the NON-Claude
+#                  copies — only needed if a harness rejects unknown frontmatter keys
+#   -NoProfile     don't modify any PowerShell profile; just print the dot-source line
+#   -Uninstall     remove this bundle's footprint via the install manifest; skills a
+#                  sibling bundle (e.g. claude-osint) still owns are kept
+#   -Help          show this help
+#
+# Idempotent. Re-runs skip skills already installed and identical; otherwise the
+# existing skill/command is backed up OUTSIDE the loading path
+# (~\.claude\install-backups\<ts>\) so backups never load as duplicate skills.
+# An install manifest is written to ~\.claude\.skill-manifests\ for clean uninstall.
+# =====================================================================
+
+[CmdletBinding()]
+param(
+    [switch] $Agents,
+    [switch] $Hermes,
+    [switch] $All,
+    [switch] $BurpMcp,
+    [switch] $NormalizeFrontmatter,
+    [switch] $NoProfile,
+    [switch] $Uninstall,
+    [switch] $Help
+)
+
+$ErrorActionPreference = 'Stop'
+
+# --- repo + paths -------------------------------------------------------
+$RepoDir    = Split-Path -Parent $PSScriptRoot            # parent of scripts\
+$Timestamp  = (Get-Date).ToString('yyyyMMdd-HHmmss')
+$BackupDest = Join-Path $HOME ".claude\install-backups\$Timestamp"
+
+$BundleName   = 'claude-bughunter'
+$ManifestDir  = Join-Path $HOME '.claude\.skill-manifests'
+$Manifest     = Join-Path $ManifestDir "$BundleName.txt"
+$ScriptsDest  = Join-Path $HOME '.claude\scripts'
+$SkillsSource = Join-Path $RepoDir 'skills'
+$CommandsSrc  = Join-Path $RepoDir 'commands'
+$HuntSrc      = Join-Path $RepoDir 'scripts\hunt.ps1'
+
+if ($Help) {
+    # Print only the leading `# ===` comment header (up to the closing rule).
+    $lines = Get-Content $PSCommandPath
+    $end = 0
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        if ($lines[$i] -match '^# ={30,}\s*$' -and $i -gt 0) { $end = $i; break }
+    }
+    if ($end -eq 0) { $end = 45 }
+    $lines[0..($end - 1)] |
+        ForEach-Object { ($_ -replace '^# ?', '') } |
+        Where-Object { $_ -ne '' -and $_ -notmatch '^={30,}\s*$' }
+    exit 0
+}
+
+# --- helpers -----------------------------------------------------------
+
+# Resolve a Python interpreter. Bash scripts hardcode `python3`, which is not
+# the Windows convention (only `python.exe` / `py.exe` ship on Windows). Probe
+# py launcher -> python -> python3 in that order.
+function Get-Python {
+    foreach ($c in @(@( 'py', '-3' ), 'python', 'python3')) {
+        $exe = $c[0]
+        if (Get-Command $exe -ErrorAction SilentlyContinue) {
+            return , $c   # array of arg(s)
+        }
+    }
+    return $null
+}
+
+# BOM-free UTF-8 writer. PS 5.1's Set-Content -Encoding UTF8 emits a BOM, which
+# breaks some tools that read these files.
+function Write-HuntFile([string] $Path, [string] $Content) {
+    $parent = Split-Path -Parent $Path
+    if ($parent -and -not (Test-Path -LiteralPath $parent)) {
+        New-Item -ItemType Directory -Force -Path $parent | Out-Null
+    }
+    $enc = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($Path, $Content, $enc)
+}
+
+# diff -rq --exclude=__pycache__ <src> <dst>  ->  $true if byte-identical.
+# Compare relative path + file bytes, ignoring __pycache__ dirs.
+function Test-DirsEqual([string] $A, [string] $B) {
+    function Get-RelFiles([string] $Root) {
+        if (-not (Test-Path -LiteralPath $Root)) { return @() }
+        Get-ChildItem -LiteralPath $Root -Recurse -File -Force |
+            Where-Object { $_.FullName -notmatch '[\\/]__pycache__([\\/]|$)' } |
+            ForEach-Object {
+                $baseLen = $Root.TrimEnd('\', '/').Length
+                $rel = $_.FullName.Substring($baseLen).TrimStart('\', '/')
+                [pscustomobject]@{ Rel = $rel; Hash = (Get-FileHash -LiteralPath $_.FullName -Algorithm MD5).Hash }
+            }
+    }
+    $fa = Get-RelFiles $A
+    $fb = Get-RelFiles $B
+    if ($fa.Count -ne $fb.Count) { return $false }
+    $map = @{}; foreach ($x in $fa) { $map[$x.Rel] = $x.Hash }
+    foreach ($x in $fb) {
+        if (-not $map.ContainsKey($x.Rel)) { return $false }
+        if ($map[$x.Rel] -ne $x.Hash) { return $false }
+    }
+    return $true
+}
+
+function Test-FilesEqual([string] $A, [string] $B) {
+    if (-not (Test-Path -LiteralPath $A) -or -not (Test-Path -LiteralPath $B)) { return $false }
+    $ha = (Get-FileHash -LiteralPath $A -Algorithm MD5).Hash
+    $hb = (Get-FileHash -LiteralPath $B -Algorithm MD5).Hash
+    return $ha -eq $hb
+}
+
+# Copy a skill dir, backing up an existing same-name dir OUTSIDE the loading path.
+function Install-Skills([string] $Dest, [string] $Label) {
+    if (-not (Test-Path -LiteralPath $Dest)) { New-Item -ItemType Directory -Force -Path $Dest | Out-Null }
+    Write-Host "Skills ->  $Dest   ($Label)"
+    $skillDirs = Get-ChildItem -LiteralPath $SkillsSource -Directory
+    foreach ($sd in $skillDirs) {
+        $name = $sd.Name
+        $target = Join-Path $Dest $name
+        if (Test-Path -LiteralPath $target -PathType Container) {
+            if (Test-DirsEqual $sd.FullName $target) { continue }   # identical -> skip
+            $bk = Join-Path $BackupDest $Label
+            New-Item -ItemType Directory -Force -Path $bk | Out-Null
+            Move-Item -LiteralPath $target (Join-Path $bk $name) -Force
+        }
+        Copy-Item -LiteralPath $sd.FullName -Destination $target -Recurse -Force
+    }
+    Write-Host "  + $($skillDirs.Count) skills installed"
+    Write-Host ''
+}
+
+# --- flag plumbing -----------------------------------------------------
+$DO_AGENTS = [bool]$Agents; $DO_HERMES = [bool]$Hermes; $DO_MCP = [bool]$BurpMcp
+$NORMALIZE = [bool]$NormalizeFrontmatter; $DETECT = [bool]$All
+$DO_UNINSTALL = [bool]$Uninstall; $NO_PROFILE = [bool]$NoProfile
+$HAS_CLAUDE = $false; $HAS_OPENCODE = $false; $HAS_CODEX = $false; $HAS_HERMES = $false
+
+# --- Uninstall ---------------------------------------------------------
+function Uninstall-Bundle {
+    if (-not (Test-Path -LiteralPath $Manifest)) {
+        Write-Host "No manifest at $Manifest -- nothing tracked to uninstall."
+        Write-Host "(Installed before manifests existed? See INSTALL.md for manual removal.)"
+        return
+    }
+    Write-Host "Uninstalling $BundleName using $Manifest"
+    $others = @(Get-ChildItem -LiteralPath $ManifestDir -Filter *.txt -File -ErrorAction SilentlyContinue |
+                Where-Object { $_.FullName -ne $Manifest })
+    $otherSets = foreach ($o in $others) {
+        ,(Get-Content -LiteralPath $o.FullName | Where-Object { $_ })
+    }
+    $removed = 0; $kept = 0
+    foreach ($rel in (Get-Content -LiteralPath $Manifest | Where-Object { $_ })) {
+        $target = Join-Path $HOME ".claude\$rel"
+        $owned = $false
+        foreach ($s in $otherSets) { if ($s -contains $rel) { $owned = $true; break } }
+        if ($owned) { $kept++ } else {
+            if (Test-Path -LiteralPath $target) { Remove-Item -LiteralPath $target -Recurse -Force -ErrorAction SilentlyContinue }
+            $removed++
+        }
+    }
+    Remove-Item -LiteralPath $Manifest -Force -ErrorAction SilentlyContinue
+    Write-Host "  + removed $removed item(s); kept $kept still owned by another bundle"
+
+    # Strip the hunt.ps1 dot-source line from any PowerShell profile(s).
+    $profiles = @(
+        $PROFILE.CurrentUserCurrentHost,
+        $PROFILE.CurrentUserAllHosts,
+        $PROFILE.AllUsersCurrentHost,
+        $PROFILE.AllUsersAllHosts
+    ) | Where-Object { $_ -and (Test-Path -LiteralPath $_) }
+    foreach ($p in $profiles) {
+        $content = Get-Content -Raw -LiteralPath $p
+        if ($content -match 'scripts[\\/]hunt\.ps1') {
+            $bak = "$p.bak"
+            Copy-Item -LiteralPath $p -Destination $bak -Force
+            $filtered = $content -split "`r?`n" |
+                Where-Object { $_ -notmatch 'scripts[\\/]hunt\.ps1' -and $_ -notmatch 'Bug-bounty engagement scaffolding' }
+            Write-HuntFile $p ($filtered -join "`r`n")
+            Write-Host "  + removed hunt.ps1 source line from $p (backup: $bak)"
+        }
+    }
+    Write-Host "Done. (Install backups remain under ~\.claude\install-backups\.)"
+}
+
+if ($DO_UNINSTALL) { Uninstall-Bundle; exit 0 }
+
+# --- --All: detect harnesses ------------------------------------------
+if ($DETECT) {
+    if ((Get-Command claude -ErrorAction SilentlyContinue) -or (Test-Path (Join-Path $HOME '.claude'))) { $HAS_CLAUDE = $true }
+    if ((Get-Command opencode -ErrorAction SilentlyContinue) -or (Test-Path (Join-Path $HOME '.config\opencode'))) { $HAS_OPENCODE = $true }
+    if ((Get-Command codex -ErrorAction SilentlyContinue) -or (Test-Path (Join-Path $HOME '.codex'))) { $HAS_CODEX = $true }
+    if ((Get-Command hermes -ErrorAction SilentlyContinue) -or (Test-Path (Join-Path $HOME '.hermes'))) { $HAS_HERMES = $true }
+    Write-Host "Detecting installed harnesses:"
+    if ($HAS_CLAUDE)   { Write-Host "  + Claude Code   -> ~\.claude\skills" }
+    if ($HAS_OPENCODE) { Write-Host "  + OpenCode      -> reads ~\.claude\skills (MCP wired separately)" }
+    if ($HAS_CODEX)    { Write-Host "  + Codex CLI     -> ~\.agents\skills" }
+    if ($HAS_HERMES)   { Write-Host "  + Hermes Agent  -> ~\.hermes\skills" }
+    if (-not ($HAS_OPENCODE -or $HAS_CODEX -or $HAS_HERMES)) {
+        Write-Host "  (only Claude Code detected -- installing there. Force others with -Agents / -Hermes.)"
+    }
+    Write-Host ''
+    if ($HAS_CODEX)  { $DO_AGENTS = $true }
+    if ($HAS_HERMES) { $DO_HERMES = $true }
+}
+
+if (-not (Test-Path -LiteralPath $SkillsSource -PathType Container)) {
+    throw "skills/ not found at $SkillsSource -- run this from inside the cloned repo."
+}
+$skillCount = (Get-ChildItem -LiteralPath $SkillsSource -Directory).Count
+
+# --- Claude Code (always): skills + commands + hunt.ps1 ----------------
+Write-Host "Installing Claude-BugHunter bundle from $RepoDir"
+if ($DO_AGENTS -or $DO_HERMES) { Write-Host "(multi-harness mode)" }
+Write-Host ''
+
+Install-Skills (Join-Path $HOME '.claude\skills') 'skills'
+
+# commands -> ~/.claude/commands
+if (Test-Path -LiteralPath $CommandsSrc) {
+    $cmdDest = Join-Path $HOME '.claude\commands'
+    if (-not (Test-Path -LiteralPath $cmdDest)) { New-Item -ItemType Directory -Force -Path $cmdDest | Out-Null }
+    Write-Host "Commands ->  $cmdDest   (Claude Code only)"
+    foreach ($f in (Get-ChildItem -LiteralPath $CommandsSrc -Filter *.md -File)) {
+        $dst = Join-Path $cmdDest $f.Name
+        if (Test-Path -LiteralPath $dst) {
+            if (Test-FilesEqual $f.FullName $dst) { continue }
+            $bk = Join-Path $BackupDest 'commands'
+            New-Item -ItemType Directory -Force -Path $bk | Out-Null
+            Move-Item -LiteralPath $dst (Join-Path $bk $f.Name) -Force
+        }
+        Copy-Item -LiteralPath $f.FullName -Destination $dst -Force
+    }
+    Write-Host "  + commands installed"
+    Write-Host ''
+}
+
+# hunt.ps1 -> ~/.claude/scripts + profile wiring
+if (-not (Test-Path -LiteralPath $ScriptsDest)) { New-Item -ItemType Directory -Force -Path $ScriptsDest | Out-Null }
+Copy-Item -LiteralPath $HuntSrc -Destination (Join-Path $ScriptsDest 'hunt.ps1') -Force
+Write-Host "  + Installed hunt command at $(Join-Path $ScriptsDest 'hunt.ps1')"
+
+# Profile wiring (equivalent of appending to .zshrc/.bashrc).
+$dotLine = '. "$HOME\.claude\scripts\hunt.ps1"'
+if ($NO_PROFILE) {
+    Write-Host "  -NoProfile: leaving your PowerShell profile untouched. To enable the 'hunt' command,"
+    Write-Host "    add this one line to your `$PROFILE yourself:"
+    Write-Host "        $dotLine"
+} else {
+    $prof = $PROFILE.CurrentUserCurrentHost
+    $profDir = Split-Path -Parent $prof
+    if (-not (Test-Path -LiteralPath $profDir)) { New-Item -ItemType Directory -Force -Path $profDir | Out-Null }
+    $needLine = $true
+    if (Test-Path -LiteralPath $prof) {
+        if ((Get-Content -Raw -LiteralPath $prof) -match 'scripts[\\/]hunt\.ps1') {
+            $needLine = $false
+        }
+    }
+    if ($needLine) {
+        $new = "# Bug-bounty engagement scaffolding (Claude-BugHunter)`r`n$dotLine`r`n"
+        if (Test-Path -LiteralPath $prof) {
+            Add-Content -LiteralPath $prof -Value "`r`n$new" -Encoding UTF8
+        } else {
+            Write-HuntFile $prof $new
+        }
+        Write-Host "  + Added this line to $prof (re-run with -NoProfile to skip this):"
+        Write-Host "        $dotLine"
+    } else {
+        Write-Host "  + hunt.ps1 already dot-sourced from $prof"
+    }
+}
+Write-Host ''
+
+# --- write install manifest -------------------------------------------
+if (-not (Test-Path -LiteralPath $ManifestDir)) { New-Item -ItemType Directory -Force -Path $ManifestDir | Out-Null }
+$entries = @()
+foreach ($d in (Get-ChildItem -LiteralPath $SkillsSource -Directory)) { $entries += "skills/$($d.Name)" }
+if (Test-Path -LiteralPath $CommandsSrc) {
+    foreach ($f in (Get-ChildItem -LiteralPath $CommandsSrc -Filter *.md -File)) { $entries += "commands/$($f.Name)" }
+}
+$entries += 'scripts/hunt.ps1'
+Write-HuntFile $Manifest (($entries -join "`n") + "`n")
+Write-Host "  + Install manifest ($($entries.Count) entries) -> $Manifest"
+Write-Host "    Uninstall later with:  pwsh ./scripts/install.ps1 -Uninstall"
+Write-Host ''
+
+# --- extra harness targets (skills only) ------------------------------
+if ($DO_AGENTS) {
+    Install-Skills (Join-Path $HOME '.agents\skills') 'agents'
+    $py = Get-Python
+    if ($py) {
+        $limit = 1024
+        # Inline truncation script (ports the bash heredoc verbatim).
+        $trunc = @"
+import os, re, sys
+root, strip_extra = sys.argv[1], sys.argv[2] == '1'
+LIMIT = 1024
+for name in sorted(os.listdir(root)):
+    p = os.path.join(root, name, 'SKILL.md')
+    if not os.path.isfile(p):
+        continue
+    lines = open(p, encoding='utf-8').read().split('\n')
+    out, changed = [], False
+    for i, line in enumerate(lines):
+        m = re.match(r'^description:\s*(.*)$', line) if i < 12 else None
+        if m:
+            val = m.group(1)
+            quoted = len(val) >= 2 and val[0] == val[-1] and val[0] in '"'"'"'"'
+            inner = val[1:-1] if quoted else val
+            if len(inner) > LIMIT:
+                cut = inner[:LIMIT - 2].rsplit(' ', 1)[0].rstrip(' ,;:_-')
+                line = 'description: "' + cut + '..."'
+                changed = True
+                print('    truncated ' + name + ' description ' + str(len(inner)) + '->' + str(len(cut)+1) + ' (Codex 1024 limit)')
+        if strip_extra and i < 12 and re.match(r'^(sources|report_count):\s', line):
+            changed = True
+            continue
+        out.append(line)
+    if changed:
+        open(p, 'w', encoding='utf-8').write('\n'.join(out))
+"@
+        $truncFile = Join-Path $env:TEMP 'cbh_trunc.py'
+        Write-HuntFile $truncFile $trunc
+        $pyExe = $py[0]
+        $pyRest = @($py[1..($py.Length - 1)]) + @($truncFile, (Join-Path $HOME '.agents\skills'), "$(if ($NORMALIZE) { '1' } else { '0' })")
+        & $pyExe $pyRest
+        Remove-Item -LiteralPath $truncFile -Force -ErrorAction SilentlyContinue
+    }
+}
+if ($DO_HERMES) { Install-Skills (Join-Path $HOME '.hermes\skills') 'hermes' }
+
+# --- opt-in Burp MCP wiring -------------------------------------------
+if ($DO_MCP) {
+    $mcpTargets = @()
+    if ($DETECT) {
+        if ($HAS_OPENCODE) { $mcpTargets += '--opencode' }
+        if ($HAS_CODEX)    { $mcpTargets += '--codex' }
+        if ($HAS_HERMES)   { $mcpTargets += '--hermes' }
+    } else {
+        if ($DO_AGENTS) { $mcpTargets += '--opencode'; $mcpTargets += '--codex' }
+        if ($DO_HERMES) { $mcpTargets += '--hermes' }
+    }
+    if ($mcpTargets.Count -eq 0) {
+        Write-Host "  ! -BurpMcp found no non-Claude harness (none detected, no -Agents/-Hermes). Skipping."
+    } else {
+        $py = Get-Python
+        if ($py) {
+            $setupPy = Join-Path $RepoDir 'scripts\setup_harness_mcp.py'
+            $pyExe = $py[0]
+            $pyRest = @($py[1..($py.Length - 1)]) + @($setupPy) + $mcpTargets
+            try {
+                & $pyExe $pyRest
+            } catch {
+                Write-Host "  ! Burp MCP wiring reported an issue -- see scripts/setup_harness_mcp.py output."
+            }
+        } else {
+            Write-Host "  ! python not found -- skipping -BurpMcp. See docs/multi-harness.md for manual snippets."
+        }
+    }
+    Write-Host ''
+}
+
+# --- summary -----------------------------------------------------------
+Write-Host "============================================"
+Write-Host "+ Install complete"
+Write-Host "============================================"
+Write-Host ''
+Write-Host "Claude Code:   $(Join-Path $HOME '.claude\skills')  (+ commands, hunt.ps1)"
+if ($DO_AGENTS) { Write-Host "Codex+OpenCode: $(Join-Path $HOME '.agents\skills')" }
+if ($DO_HERMES) { Write-Host "Hermes Agent:  $(Join-Path $HOME '.hermes\skills')" }
+if (Test-Path -LiteralPath $BackupDest) { Write-Host "Backups:       $BackupDest  (outside loading paths)" }
+Write-Host ''
+if (-not $DETECT -and -not $DO_AGENTS -and -not $DO_HERMES) {
+    Write-Host "Other harnesses?  pwsh ./scripts/install.ps1 -All   (auto-detects Codex / OpenCode / Hermes)"
+    Write-Host "See also: docs/multi-harness.md"
+}
+Write-Host ''
+Write-Host "Next: open a new PowerShell window (or '. `$PROFILE') and try:  hunt acme-test"


### PR DESCRIPTION
## What

Every `.sh` installer now has a PowerShell counterpart so the bundle installs **natively on Windows** — no WSL, no Git Bash required for the core install.

| bash (macOS/Linux) | PowerShell (Windows) |
|---|---|
| `scripts/hunt.sh` | `scripts/hunt.ps1` |
| `scripts/install.sh` | `scripts/install.ps1` |
| `scripts/install-community-skills.sh` | `scripts/install-community-skills.ps1` |

## Why

The `hunt` engagement scaffolder and the copy-installer were macOS/Linux-only (bash functions sourced into `.zshrc`/`.bashrc`). Windows users had no native path. This ports all three installers to PowerShell so Windows is a first-class install target with identical behavior.

## How (faithful 1:1 port)

Same behavior, same flags (hyphen-style for PowerShell conventions), same manifest-driven uninstall:

| `install.sh` | `install.ps1` |
|---|---|
| `--all` | `-All` |
| `--agents` | `-Agents` |
| `--hermes` | `-Hermes` |
| `--burp-mcp` | `-BurpMcp` |
| `--normalize-frontmatter` | `-NormalizeFrontmatter` |
| `--no-shell` | `-NoProfile` |
| `--uninstall` | `-Uninstall` |

Tool mappings researched and applied:
- `source ~/.zshrc`-style rc wiring → `$PROFILE.CurrentUserCurrentHost` dot-sourced at session start
- `python3` (hardcoded in bash) → `Get-Python` resolving `py -3` → `python` → `python3` (Windows has no `python3` convention)
- `diff -rq --exclude=__pycache__` → MD5-hash comparison of relative paths with `__pycache__` filtered
- `sed -i.bak '/pat/d'` → backup copy + `Get-Content | Where-Object -notmatch | Set-Content`
- `chmod +x` → no-op (execution policy governs on Windows, not mode bits)
- BOM-free UTF-8 writes via `[System.IO.File]::WriteAllText` + `UTF8Encoding($false)` (PS 5.1's `Set-Content -Encoding UTF8` adds a BOM)

The Python heredocs (Codex description truncation, recon-manifest ingestion) are preserved verbatim. `hunt.ps1` is dot-sourced from the PowerShell `$PROFILE`.

## Docs

Updated to show both paths (no "use WSL" as the only Windows option): README, INSTALL, USAGE, `docs/multi-harness.md`, SECURITY, `docs/index.md`, `docs/credits.md`, CHANGELOG. macOS/Linux paths are unchanged.

## Verification

- `install.ps1 -Help` prints the header cleanly
- Real install run: 82 skills + 15 commands + `hunt.ps1` placed, manifest written (98 entries)
- `-Uninstall` removed all 98 items via manifest and stripped the profile line (with `.bak`)
- Idempotency (skip-if-identical) verified
- `hunt.ps1`: full scaffold on new target, idempotent on existing, usage on no-arg
- All three `.ps1`: parse clean, UTF-8, LF endings, no BOM
- `.gitattributes` pins `*.ps1` to `eol=lf` alongside `*.sh`/`*.py`

Tested on Windows PowerShell 5.1 (the lowest supported version).

## Checklist
- [x] Windows native install works end-to-end
- [x] macOS/Linux paths unchanged
- [x] No WSL dependency introduced
- [x] Docs updated for both platforms