### PR TITLE
chore(star-history): refresh daily + guard against truncated fetch

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -11,7 +11,7 @@ name: star-history
 
 on:
   schedule:
-    - cron: "17 4 * * 1" # Mondays, 04:17 UTC
+    - cron: "17 4 * * *" # daily, 04:17 UTC
   workflow_dispatch: # manual refresh
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ pwsh ./scripts/install.ps1 -All -BurpMcp
 </a>
 
 <sub>Chart is self-hosted — regenerate with `python3 scripts/gen_star_history.py` (needs `gh auth login`).
-Refreshes automatically each Monday via `.github/workflows/star-history.yml`.</sub>
+Refreshes automatically each day via `.github/workflows/star-history.yml`.</sub>
 
 ---
 

--- a/scripts/gen_star_history.py
+++ b/scripts/gen_star_history.py
@@ -43,6 +43,12 @@ def fetch_stars(repo):
              "-H", "Accept: application/vnd.github.star+json", "--jq", ".[].starred_at"],
             capture_output=True, text=True,
         )
+        # Distinguish a real end-of-data (rc 0, empty array) from a transient
+        # failure (rate-limit / 5xx → rc != 0). Without this, a failed page
+        # looks like "no more stars" and we'd render+commit a truncated chart
+        # with a lower count. Abort instead, leaving the committed SVGs intact.
+        if out.returncode != 0:
+            sys.exit(f"stargazers fetch failed at page {page}: {out.stderr.strip()}")
         got = [l for l in out.stdout.split("\n") if l.strip()]
         if not got:
             break


### PR DESCRIPTION
## What

The self-hosted star chart already auto-refreshes via `.github/workflows/star-history.yml`, but only **weekly** (Monday cron), so the baked count lagged up to 7 days behind the real number (it read 3,344 while the repo was at ~3,601). This switches it to **daily**.

## Changes

- **`star-history.yml`** — cron `17 4 * * 1` (Mondays) → `17 4 * * *` (daily, 04:17 UTC). Everything else unchanged; the existing `git diff --quiet` gate still no-ops on days the count didn't change, so it only commits when there's an actual update.
- **`gen_star_history.py`** — `fetch_stars()` ignored the `gh` exit code and treated any empty page as end-of-data. A rate-limited/transient failure mid-pagination would silently truncate the series and commit a chart showing a **lower** count. Daily cadence multiplies that exposure, so a non-zero `gh api` exit now aborts the run (leaving the committed SVGs intact) instead of regressing the chart.
- **`README.md`** — caption "each Monday" → "each day" to match.

## Notes

- Still fully self-hosted — no external service (no star-history.com / shields.io).
- Tradeoff (accepted): ~1 bot commit/day when the count changes.
- After merge, a manual `workflow_dispatch` run will jump the chart to the current count immediately rather than waiting for the next 04:17 UTC tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)