### PR TITLE
Add ZCode Agent support

### DIFF
--- a/.zcode-plugin/plugin.json
+++ b/.zcode-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "claude-bughunter",
+  "version": "2.1.0",
+  "description": "83-skill bug-hunting & external red-team bundle for ZCode Agent — 58 hunt-* web/vuln-class + framework skills, enterprise platform attack chains (M365/Entra, Okta, SharePoint, vCenter, SSL-VPN, APK/iOS), recon/OSINT, reporting & validation gates, and Burp MCP integration. Skills auto-load by topic; 15 slash commands included.",
+  "author": {
+    "name": "Sachin Sharma",
+    "url": "https://github.com/elementalsouls"
+  },
+  "homepage": "https://elementalsouls.github.io/Claude-BugHunter",
+  "repository": "https://github.com/elementalsouls/Claude-BugHunter",
+  "license": "MIT",
+  "keywords": [
+    "security",
+    "offensive-security",
+    "bug-bounty",
+    "red-team",
+    "pentest",
+    "recon",
+    "osint",
+    "hunt"
+  ],
+  "skills": "skills",
+  "commands": "commands"
+}

--- a/.zcode-plugin/plugin.json
+++ b/.zcode-plugin/plugin.json
@@ -20,5 +20,12 @@
     "hunt"
   ],
   "skills": "skills",
-  "commands": "commands"
+  "commands": "commands",
+  "mcpServers": {
+    "burp": {
+      "type": "sse",
+      "url": "http://127.0.0.1:9876",
+      "enabled": false
+    }
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ versioning is loosely [SemVer](https://semver.org/) at the bundle level.
   `install.ps1 -Zcode` is the copy alternative (skills → `~/.zcode/skills`, commands →
   `~/.zcode/commands`). Burp MCP registers as an SSE server: `setup_harness_mcp.py --zcode`
   writes `mcp.servers.burp = {type:"sse", url:"http://127.0.0.1:9876"}` into
-  `~/.zcode/cli/config.json`. `--all`/`-All` now detect ZCode. New guide `docs/zcode.md`
+  `~/.zcode/cli/config.json`. The plugin manifest also declares the server, disabled by
+  default — enable it under Plugin MCP servers. `--all`/`-All` now detect ZCode. New guide `docs/zcode.md`
   (incl. the skill-metadata-budget caveat); README/INSTALL/multi-harness updated.
 - **Native Windows install ** — every `.sh` installer now has a PowerShell
   counterpart: `scripts/install.ps1`, `scripts/install-community-skills.ps1`, `scripts/hunt.ps1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ versioning is loosely [SemVer](https://semver.org/) at the bundle level.
 ## [Unreleased]
 
 ### Added
+- **ZCode Agent support** — ZCode reads the same plugin layout as Claude Code (manifest at
+  `.zcode-plugin/plugin.json`, existing `.claude-plugin/` as fallback, same `marketplace.json`
+  catalog), so the 83 skills, 15 slash commands, and Burp MCP run there: Settings → Plugins →
+  Create → Add marketplace → this repo → Install. `scripts/install.sh --zcode` /
+  `install.ps1 -Zcode` is the copy alternative (skills → `~/.zcode/skills`, commands →
+  `~/.zcode/commands`). Burp MCP registers as an SSE server: `setup_harness_mcp.py --zcode`
+  writes `mcp.servers.burp = {type:"sse", url:"http://127.0.0.1:9876"}` into
+  `~/.zcode/cli/config.json`. `--all`/`-All` now detect ZCode. New guide `docs/zcode.md`
+  (incl. the skill-metadata-budget caveat); README/INSTALL/multi-harness updated.
 - **Native Windows install ** — every `.sh` installer now has a PowerShell
   counterpart: `scripts/install.ps1`, `scripts/install-community-skills.ps1`, `scripts/hunt.ps1`.
   Same behavior, same flags (hyphen-style: `-All`, `-Agents`, `-Hermes`, `-BurpMcp`, `-NoProfile`,

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -64,27 +64,29 @@ This copies:
 
 Existing skills with the same name are backed up to `~/.claude/install-backups/<timestamp>/` — **outside** the skills/commands directories, so backups never load as duplicate skills. Re-runs are non-destructive.
 
-### Run on other harnesses (OpenCode · Codex · Hermes)
+### Run on other harnesses (OpenCode · Codex · Hermes · ZCode)
 
 The skills are plain Agent Skills, so they also run outside Claude Code:
 
 ```bash
 # macOS / Linux
-./scripts/install.sh --all          # also installs to ~/.agents/skills (Codex + OpenCode) and ~/.hermes/skills (Hermes)
+./scripts/install.sh --all          # also installs to ~/.agents/skills (Codex + OpenCode), ~/.hermes/skills (Hermes), ~/.zcode (ZCode)
 ./scripts/install.sh --agents       # just Codex + OpenCode
 ./scripts/install.sh --hermes       # just Hermes
+./scripts/install.sh --zcode        # just ZCode Agent (skills + commands)
 ./scripts/install.sh --agents --burp-mcp   # also wire your Burp MCP into those harnesses
 ```
 
 ```powershell
 # Windows (PowerShell)
-pwsh ./scripts/install.ps1 -All          # Codex + OpenCode + Hermes
+pwsh ./scripts/install.ps1 -All          # Codex + OpenCode + Hermes + ZCode
 pwsh ./scripts/install.ps1 -Agents       # just Codex + OpenCode
 pwsh ./scripts/install.ps1 -Hermes       # just Hermes
+pwsh ./scripts/install.ps1 -Zcode        # just ZCode Agent (skills + commands)
 pwsh ./scripts/install.ps1 -Agents -BurpMcp   # also wire your Burp MCP into those harnesses
 ```
 
-Slash commands, the plugin marketplace, and the `/hunt` engine are Claude-Code-only; other harnesses get the skill knowledge + Burp MCP. Full details and per-harness MCP snippets: [`docs/multi-harness.md`](docs/multi-harness.md).
+Slash commands, the plugin marketplace, and the `/hunt` engine are Claude-Code- and ZCode-compatible; other harnesses get the skill knowledge + Burp MCP. Full details and per-harness MCP snippets: [`docs/multi-harness.md`](docs/multi-harness.md), [`docs/zcode.md`](docs/zcode.md).
 
 ## Step 3 — (Optional) Set up Burp MCP
 
@@ -114,6 +116,8 @@ Verify in a fresh `claude` session:
 ```
 
 You should see `burp · ✓ connected`.
+
+**On ZCode:** the recommended setup is type **SSE** with URL `http://127.0.0.1:9876` (Settings → MCP Servers → New MCP Server) — simpler than the stdio command. Or run `python3 scripts/setup_harness_mcp.py --zcode`. Details: [`docs/zcode.md`](docs/zcode.md#burp-mcp-sse).
 
 ## Step 4 — (Optional) Refresh vendored skills from upstream
 

--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ That's it. Open Claude Code and describe what you're testing in plain English �
 
 ---
 
-## Runs on four harnesses
+## Runs on five harnesses
 
-![One install, four agent harnesses — Claude Code, OpenCode, Codex CLI, Hermes Agent](assets/harness-routing.svg)
+![One install, five agent harnesses — Claude Code, OpenCode, Codex CLI, Hermes Agent, ZCode Agent](assets/harness-routing.svg)
 
-The skills are plain [Agent Skills](https://docs.claude.com/en/docs/claude-code/skills) — the same `SKILL.md` format that **Claude Code · OpenCode · OpenAI Codex CLI · Hermes Agent** all load. One command installs them everywhere:
+The skills are plain [Agent Skills](https://docs.claude.com/en/docs/claude-code/skills) — the same `SKILL.md` format that **Claude Code · OpenCode · OpenAI Codex CLI · Hermes Agent · ZCode Agent** all load. One command installs them everywhere:
 
 ```bash
 # macOS / Linux
@@ -108,9 +108,9 @@ bash scripts/install.sh --all --burp-mcp
 pwsh ./scripts/install.ps1 -All -BurpMcp
 ```
 
-`--all` (`-All`) copies the skills to every harness's path (`~/.claude/skills`, `~/.agents/skills`, `~/.hermes/skills`); `--burp-mcp` (`-BurpMcp`) wires the Burp MCP server into each. The full *knowledge* layer ports to all four — the slash commands and `/hunt` engine stay Claude-Code-only by design.
+`--all` (`-All`) copies the skills to every harness's path (`~/.claude/skills`, `~/.agents/skills`, `~/.hermes/skills`, `~/.zcode`); `--burp-mcp` (`-BurpMcp`) wires the Burp MCP server into each. The full *knowledge* layer ports to all five — the slash commands and `/hunt` engine run on Claude Code and ZCode Agent.
 
-→ [Multi-harness guide](docs/multi-harness.md)
+→ [Multi-harness guide](docs/multi-harness.md) · [ZCode guide](docs/zcode.md)
 
 ---
 

--- a/assets/harness-routing.svg
+++ b/assets/harness-routing.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 290" width="1080" height="290" role="img" aria-label="Claude-BugHunter harness routing card">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1330 290" width="1330" height="290" role="img" aria-label="Claude-BugHunter harness routing card">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#08080d"/>
@@ -17,13 +17,13 @@
     </style>
   </defs>
 
-  <rect width="1080" height="290" fill="url(#bg)"/>
-  <rect width="1080" height="290" fill="url(#grid)"/>
+  <rect width="1330" height="290" fill="url(#bg)"/>
+  <rect width="1330" height="290" fill="url(#grid)"/>
 
   <g transform="translate(20 20)">
-    <rect x="0" y="0" width="1040" height="250" rx="8" fill="#0b0c12" stroke="#2a2c3a"/>
+    <rect x="0" y="0" width="1290" height="250" rx="8" fill="#0b0c12" stroke="#2a2c3a"/>
     <text x="28" y="40" class="mono dim" font-size="12" font-weight="800" letter-spacing="2.2">HARNESS ROUTING</text>
-    <line x1="172" y1="36" x2="1012" y2="36" stroke="#1d1f2b"/>
+    <line x1="172" y1="36" x2="1262" y2="36" stroke="#1d1f2b"/>
 
     <!-- box 1 : Claude Code -->
     <g transform="translate(28 60)">
@@ -57,8 +57,16 @@
       <line x1="18" y1="62" x2="220" y2="62" stroke="#23242f"/>
       <text x="18" y="90" class="mono muted" font-size="11.5" letter-spacing="0.6">~/.hermes/skills</text>
     </g>
+    <!-- box 5 : ZCode Agent -->
+    <g transform="translate(1028 60)">
+      <rect width="238" height="112" rx="6" fill="#12131c" stroke="#34d399"/>
+      <g transform="translate(18 16) scale(1.166)" fill="#34d399"><path d="M5 4h14v3.2l-8.4 9.6H19V20H5v-3.2l8.4-9.6H5z"/></g>
+      <text x="56" y="35" class="mono white" font-size="13" font-weight="800" letter-spacing="0.8">ZCode Agent</text>
+      <line x1="18" y1="62" x2="220" y2="62" stroke="#23242f"/>
+      <text x="18" y="90" class="mono muted" font-size="11.5" letter-spacing="0.6">~/.zcode/skills</text>
+    </g>
 
     <text x="28" y="218" class="mono" font-size="14"><tspan class="red" font-weight="800">$ </tspan><tspan class="white">bash scripts/install.sh --all --burp-mcp</tspan></text>
-    <text x="1012" y="218" text-anchor="end" class="mono dim" font-size="12" letter-spacing="1.2">ONE COMMAND - FOUR HARNESSES</text>
+    <text x="1262" y="218" text-anchor="end" class="mono dim" font-size="12" letter-spacing="1.2">ONE COMMAND - FIVE HARNESSES</text>
   </g>
 </svg>

--- a/assets/harness-routing.svg
+++ b/assets/harness-routing.svg
@@ -60,7 +60,7 @@
     <!-- box 5 : ZCode Agent -->
     <g transform="translate(1028 60)">
       <rect width="238" height="112" rx="6" fill="#12131c" stroke="#34d399"/>
-      <g transform="translate(18 16) scale(1.166)" fill="#34d399"><path d="M5 4h14v3.2l-8.4 9.6H19V20H5v-3.2l8.4-9.6H5z"/></g>
+      <g transform="translate(18 16) scale(0.11)" fill="#34d399"><path d="M134.4 0.130152L116.48 25.6022C113.665 29.5699 109.054 32.0019 104.064 32.0019H6.3999V0C6.3999 0.130149 134.4 0.130152 134.4 0.130152Z"/><path d="M256 0.130127L102.401 217.732H0L153.599 0.130127H256Z"/><path d="M121.601 217.732L139.65 192.134C142.465 188.166 147.076 185.734 152.067 185.734H249.604V217.736H121.601V217.732Z"/></g>
       <text x="56" y="35" class="mono white" font-size="13" font-weight="800" letter-spacing="0.8">ZCode Agent</text>
       <line x1="18" y1="62" x2="220" y2="62" stroke="#23242f"/>
       <text x="18" y="90" class="mono muted" font-size="11.5" letter-spacing="0.6">~/.zcode/skills</text>

--- a/assets/harness-routing.svg
+++ b/assets/harness-routing.svg
@@ -59,8 +59,8 @@
     </g>
     <!-- box 5 : ZCode Agent -->
     <g transform="translate(1028 60)">
-      <rect width="238" height="112" rx="6" fill="#12131c" stroke="#34d399"/>
-      <g transform="translate(18 16) scale(0.11)" fill="#34d399"><path d="M134.4 0.130152L116.48 25.6022C113.665 29.5699 109.054 32.0019 104.064 32.0019H6.3999V0C6.3999 0.130149 134.4 0.130152 134.4 0.130152Z"/><path d="M256 0.130127L102.401 217.732H0L153.599 0.130127H256Z"/><path d="M121.601 217.732L139.65 192.134C142.465 188.166 147.076 185.734 152.067 185.734H249.604V217.736H121.601V217.732Z"/></g>
+      <rect width="238" height="112" rx="6" fill="#12131c" stroke="#9aa0ae"/>
+      <g transform="translate(18 16) scale(0.11)" fill="#e8e8ee"><path d="M134.4 0.130152L116.48 25.6022C113.665 29.5699 109.054 32.0019 104.064 32.0019H6.3999V0C6.3999 0.130149 134.4 0.130152 134.4 0.130152Z"/><path d="M256 0.130127L102.401 217.732H0L153.599 0.130127H256Z"/><path d="M121.601 217.732L139.65 192.134C142.465 188.166 147.076 185.734 152.067 185.734H249.604V217.736H121.601V217.732Z"/></g>
       <text x="56" y="35" class="mono white" font-size="13" font-weight="800" letter-spacing="0.8">ZCode Agent</text>
       <line x1="18" y1="62" x2="220" y2="62" stroke="#23242f"/>
       <text x="18" y="90" class="mono muted" font-size="11.5" letter-spacing="0.6">~/.zcode/skills</text>

--- a/docs/multi-harness.md
+++ b/docs/multi-harness.md
@@ -1,14 +1,14 @@
 ---
 title: Multi-harness install
 nav_order: 3
-description: Run the Claude-BugHunter skills on OpenCode, Codex, and Hermes Agent — not just Claude Code.
+description: Run the Claude-BugHunter skills on OpenCode, Codex, Hermes Agent, and ZCode Agent — not just Claude Code.
 ---
 
 # Multi-harness install
 
-The 83 skills are plain **Agent Skills** (`SKILL.md` = `name` + `description` frontmatter + Markdown). That format is an open standard, so the *knowledge* runs on more than Claude Code. This page shows how to install it on **OpenCode**, **OpenAI Codex CLI**, and **Hermes Agent**.
+The 83 skills are plain **Agent Skills** (`SKILL.md` = `name` + `description` frontmatter + Markdown). That format is an open standard, so the *knowledge* runs on more than Claude Code. This page shows how to install it on **OpenCode**, **OpenAI Codex CLI**, **Hermes Agent**, and **ZCode Agent**.
 
-> **What ports and what doesn't.** The **83 skills** (payloads, methodology, bypass tables, disclosed-report patterns) port to every harness below. The **`/hunt` slash commands, the plugin marketplace, and the `hunt-dispatch` subagent routing are Claude-Code-specific** and do **not** port — other harnesses get the knowledge, not the orchestration engine. **Burp MCP** ports to all of them (it's just an MCP server).
+> **What ports and what doesn't.** The **83 skills** (payloads, methodology, bypass tables, disclosed-report patterns) port to every harness below. The **`/hunt` slash commands, the plugin marketplace, and the `hunt-dispatch` subagent routing are Claude-Code-specific** and do **not** port — other harnesses get the knowledge, not the orchestration engine. **Burp MCP** ports to all of them (it's just an MCP server). **ZCode Agent** also reads the plugin layout and slash commands — see [zcode.md](zcode.md).
 
 ## Compatibility matrix (verified mid-2026)
 
@@ -18,8 +18,9 @@ The 83 skills are plain **Agent Skills** (`SKILL.md` = `name` + `description` fr
 | **OpenCode** | ✅ native | reads `~/.claude/skills/` **and** `~/.agents/skills/` | ✅ `opencode.json` | ✅ own format |
 | **Codex CLI** | ✅ native | `~/.agents/skills/` (does *not* read `~/.claude/`) | ✅ `~/.codex/config.toml` | ✅ own format |
 | **Hermes Agent** | ✅ (agentskills.io) | `~/.hermes/skills/` | ✅ | ✅ own format |
+| **ZCode Agent** | ✅ native | plugin install, or `~/.zcode/skills/` | ✅ SSE | ✅ same commands (`/hunt`, …) |
 
-**Key:** `~/.agents/skills/` is the shared path read by **Codex + OpenCode**. So two copies cover everything: `~/.claude/skills/` (Claude) + `~/.agents/skills/` (Codex + OpenCode), plus `~/.hermes/skills/` for Hermes. Required frontmatter is identical across all four (`name` lowercase-hyphen ≤64, `description` ≤1024) — our `scripts/lint_skills.py` enforces it, so **no per-skill conversion is needed**.
+**Key:** `~/.agents/skills/` is the shared path read by **Codex + OpenCode**. So two copies cover everything: `~/.claude/skills/` (Claude) + `~/.agents/skills/` (Codex + OpenCode), plus `~/.hermes/skills/` for Hermes. ZCode installs via the plugin marketplace, or the `--zcode`/`-Zcode` copy path. Required frontmatter is identical across all five (`name` lowercase-hyphen ≤64, `description` ≤1024) — our `scripts/lint_skills.py` enforces it, so **no per-skill conversion is needed**.
 
 ## Install
 
@@ -46,6 +47,7 @@ Pick specific harnesses instead:
 bash scripts/install.sh                 # Claude Code only (default)
 bash scripts/install.sh --agents        # + Codex & OpenCode (~/.agents/skills)
 bash scripts/install.sh --hermes        # + Hermes Agent (~/.hermes/skills)
+bash scripts/install.sh --zcode         # + ZCode Agent (~/.zcode/skills + commands)
 ```
 
 ```powershell
@@ -53,11 +55,12 @@ bash scripts/install.sh --hermes        # + Hermes Agent (~/.hermes/skills)
 pwsh ./scripts/install.ps1              # Claude Code only (default)
 pwsh ./scripts/install.ps1 -Agents      # + Codex & OpenCode (~/.agents/skills)
 pwsh ./scripts/install.ps1 -Hermes      # + Hermes Agent (~/.hermes/skills)
+pwsh ./scripts/install.ps1 -Zcode       # + ZCode Agent (~/.zcode\skills + commands)
 ```
 
 - **OpenCode** already reads `~/.claude/skills/`, so the plain installer (no flags) is enough for OpenCode — you don't need `--agents`/`-Agents` for it. That flag exists mainly for **Codex** (which reads only `~/.agents/skills/`).
   - *Caveat (verified):* OpenCode reads **both** `~/.claude/skills/` and `~/.agents/skills/`. If both are populated (e.g. you ran `--all`/`-All` for Codex too), OpenCode logs harmless `duplicate skill name` warnings and loads one copy — all 83 skills still work. Only populate `~/.agents/skills/` if you actually use Codex.
-- **Codex is the strict parser** (verified by testing): it hard-rejects descriptions > 1024 chars and invalid YAML, where Claude/OpenCode/Hermes are lenient. So the installer **auto-truncates** any description > 1024 to ≤1024 **only in the `~/.agents/skills` (Codex) copy** — your `~/.claude` and `~/.hermes` copies keep the full descriptions (incl. non-English trigger words). The install logs which were truncated (today: the 3 aggregator router skills). `--normalize-frontmatter` (`-NormalizeFrontmatter`) additionally strips the non-standard `sources:`/`report_count:` keys (optional — Codex tolerates them).
+- **Codex and ZCode are the strict parsers** (verified by testing): Codex hard-rejects descriptions > 1024 chars and invalid YAML, and ZCode drops the whole skill, where Claude/OpenCode/Hermes are lenient. So the installer **auto-truncates** any description > 1024 to ≤1024 **only in the `~/.agents/skills` (Codex) and `~/.zcode/skills` (ZCode) copies** — your `~/.claude` and `~/.hermes` copies keep the full descriptions (incl. non-English trigger words). The install logs which were truncated (today: the 3 aggregator router skills). ZCode's **plugin** install has no copy step, so those 3 skills are dropped there — use the copy installer for all 83. `--normalize-frontmatter` (`-NormalizeFrontmatter`) additionally strips the non-standard `sources:`/`report_count:` keys (optional — Codex tolerates them).
 
 ## Burp MCP on other harnesses
 
@@ -98,6 +101,24 @@ args = ["-jar", "~/.BurpSuite/mcp-proxy/mcp-proxy-all.jar", "--sse-url", "http:/
 
 **Hermes** — see the [Hermes MCP guide](https://hermes-agent.nousresearch.com/docs/guides/use-mcp-with-hermes); use the same `java -jar … --sse-url …` command.
 
+**ZCode** — the recommended setup is the SSE type (simpler than the stdio snippets above); `--zcode --burp-mcp` (`-Zcode -BurpMcp`) writes it:
+
+`~/.zcode/cli/config.json`
+```json
+{
+  "mcp": {
+    "servers": {
+      "burp": {
+        "type": "sse",
+        "url": "http://127.0.0.1:9876",
+        "enabled": true
+      }
+    }
+  }
+}
+```
+
 ## Verify it loaded
 - **OpenCode / Codex / Hermes:** open the tool and describe a task (e.g. *"test this endpoint for SSRF"*) — the matching `hunt-*` skill should auto-load by its description, same as in Claude Code.
 - **Hermes:** `hermes skills` should list the bundle from `~/.hermes/skills/`.
+- **ZCode:** new session, then check Settings → Skills and the `/` panel — or invoke with `$hunt-ssrf`. Details: [zcode.md](zcode.md).

--- a/docs/zcode.md
+++ b/docs/zcode.md
@@ -16,7 +16,7 @@ ZCode Agent reads the same plugin layout as Claude Code, so the skills, the 15 s
 |---|---|---|
 | 83 skills | ✅ auto-trigger by topic | Settings → Skills → Plugin skills; `$skill-name` in chat |
 | 15 slash commands | ✅ same commands | `/` panel → Commands group (`/hunt`, `/recon`, `/report`, …) |
-| Burp MCP | ✅ SSE | Settings → MCP → Configured servers → `burp` |
+| Burp MCP | ✅ SSE | Settings → MCP → enable the bundled `burp` entry (Plugin MCP servers) |
 | `cbh` CLI + `engine/` | ✅ plain Python, harness-agnostic | terminal |
 
 ## Install — Option A: plugin via marketplace
@@ -52,6 +52,8 @@ pwsh ./scripts/install.ps1 -Zcode
 ## Burp MCP (SSE)
 
 The Burp Suite **MCP Server** BApp extension listens as an SSE server on `http://127.0.0.1:9876`. Registering that URL with `type: sse` is the recommended setup — simpler than a stdio command.
+
+The plugin ships this entry disabled by default — enable **burp** under Plugin MCP servers in Settings → MCP once Burp is running. Or add it yourself:
 
 **GUI:** Settings → MCP Servers → **New MCP Server** → type **SSE** → URL `http://127.0.0.1:9876` → Add.
 

--- a/docs/zcode.md
+++ b/docs/zcode.md
@@ -1,0 +1,108 @@
+---
+title: ZCode Agent install
+nav_order: 4
+description: Run Claude-BugHunter inside ZCode Agent — plugin marketplace install, slash commands, and Burp MCP setup.
+---
+
+# ZCode Agent install
+
+ZCode Agent reads the same plugin layout as Claude Code, so the skills, the 15 slash commands, and Burp MCP all run there. Install routes and wiring are below.
+
+> ZCode discovers a plugin manifest at **`.zcode-plugin/plugin.json`** first and falls back to **`.claude-plugin/plugin.json`** (Claude Code compatible). This repo ships both, and the single `.claude-plugin/marketplace.json` catalog serves ZCode as well — nothing is forked or duplicated.
+
+## What works in ZCode
+
+| Component | Status | Where it shows up |
+|---|---|---|
+| 83 skills | ✅ auto-trigger by topic | Settings → Skills → Plugin skills; `$skill-name` in chat |
+| 15 slash commands | ✅ same commands | `/` panel → Commands group (`/hunt`, `/recon`, `/report`, …) |
+| Burp MCP | ✅ SSE | Settings → MCP → Configured servers → `burp` |
+| `cbh` CLI + `engine/` | ✅ plain Python, harness-agnostic | terminal |
+
+## Install — Option A: plugin via marketplace
+
+1. Open **Settings → Plugins** (a workspace must be open).
+2. Click **Create → Add marketplace** (top-right) and point it at this repo:
+   - **From GitHub:** `elementalsouls/Claude-BugHunter`
+   - **From a local clone:** pick the directory with the *Choose directory* button
+3. Find **claude-bughunter** under your marketplace in the *Personal* segment and click **Install**.
+4. Verify: **Settings → Skills** shows the plugin's skills; the `/` panel lists the commands; a new session auto-triggers skills by topic.
+
+Components register and unregister together with the plugin's enable switch; updates arrive on version bump.
+
+> Limitation: the 3 aggregator skills with >1024-char descriptions (`bug-bounty`, `bb-local-toolkit`, `osint-methodology`) are dropped in plugin mode — see [Compatibility notes](#compatibility-notes). Use the copy installer below for all 83.
+
+## Install — Option B: copy installer (no marketplace)
+
+```bash
+# macOS / Linux
+bash scripts/install.sh --zcode      # skills → ~/.zcode/skills, commands → ~/.zcode/commands
+```
+
+```powershell
+# Windows (PowerShell)
+pwsh ./scripts/install.ps1 -Zcode
+```
+
+`--all` / `-All` auto-detects ZCode (the `zcode` binary on PATH or `~/.zcode` existing) and includes it. Notes:
+
+- This path is **not** tracked by the `~/.claude` uninstall manifest — remove manually (`rm -rf ~/.zcode/skills/<name>`, delete `~/.zcode/commands/<cmd>.md`) or just use Option A.
+- User-scope skills **shadow** plugin skills of the same name in ZCode. If you previously copied skills and now install the plugin, remove the copies to avoid stale duplicates winning.
+
+## Burp MCP (SSE)
+
+The Burp Suite **MCP Server** BApp extension listens as an SSE server on `http://127.0.0.1:9876`. Registering that URL with `type: sse` is the recommended setup — simpler than a stdio command.
+
+**GUI:** Settings → MCP Servers → **New MCP Server** → type **SSE** → URL `http://127.0.0.1:9876` → Add.
+
+**CLI (writes the same thing):**
+
+```bash
+python3 scripts/setup_harness_mcp.py --zcode          # default SSE URL http://127.0.0.1:9876
+python3 scripts/setup_harness_mcp.py --zcode --sse-url http://localhost:9876
+```
+
+**Resulting entry** in `~/.zcode/cli/config.json` (ZCode's user config uses the *nested* `mcp.servers` key — a top-level `mcpServers` is not read there):
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "burp": {
+        "type": "sse",
+        "url": "http://127.0.0.1:9876",
+        "enabled": true
+      }
+    }
+  }
+}
+```
+
+The script merges into the existing config (backing it up first) — it never overwrites unrelated keys. Start a **new** ZCode session with Burp running and the extension listening; the server row should show connected, and Burp tools (`send_http1_request`, proxy history, Repeater tabs, …) become available to the agent.
+
+## Skill metadata budget
+
+ZCode injects every **enabled** skill's metadata (name + ~250-char description excerpt) into each turn, under one **fixed shared budget**. This bundle alone contributes 83 skills; add other plugins and the budget can overflow, at which point injection degrades to **names only** and auto-triggering stops working reliably.
+
+Practical guidance:
+
+- Keep enabled only the families you're actively using (e.g. the `hunt-*` web stack for a web engagement) and disable the rest in **Settings → Skills** — disabled skills can still be invoked explicitly.
+- Invoke any disabled-or-not skill deterministically with `$skill-name` (e.g. `$hunt-sqli`) or via the Skills group in the `/` panel.
+- Re-run `--all`-style workflows per-engagement: enable `m365-entra-attack` + `okta-attack` for an identity engagement, then swap back.
+
+## Compatibility notes
+
+- **Description limit is a hard drop.** ZCode discards a whole skill whose `description` exceeds **1024 chars** (same limit Codex enforces). Three aggregator skills (`bug-bounty`, `bb-local-toolkit`, `osint-methodology`) intentionally ship longer descriptions in the repo, so they are dropped in **plugin** mode — the copy installer below truncates just those copies and loads all 83.
+- **Extra frontmatter keys** (`sources:`, `report_count:`, `triggers:`) are ignored harmlessly by ZCode — no `--normalize-frontmatter` needed.
+- **Commands** use only `name` + `description` frontmatter; names match ZCode's `[a-z0-9][a-z0-9_:-]{1,64}` rule. Arguments arrive the same way (`$ARGUMENTS` if a command uses it).
+- **Session snapshot:** skills, commands, MCP servers, and plugin state are snapshotted at session start — after installing or toggling anything, verify in a **new** session.
+- **Engine skill resolution:** `engine/skill_map.py` finds the skills next to the engine (repo checkout and plugin install) and falls back to `~/.claude/skills`, then `~/.zcode/skills`. Override with `$CBH_SKILLS_DIR` for exotic layouts.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| Skills visible but never auto-trigger | Metadata budget overflowed — disable unused skills (see above), or invoke explicitly with `$skill-name` |
+| Plugin not listed after adding marketplace | Refresh the marketplace in the sources panel; check the manifest is at `.zcode-plugin/plugin.json` or `.claude-plugin/plugin.json` |
+| `/hunt` missing from the `/` panel | New session (config is snapshotted at startup); confirm the plugin is enabled |
+| Burp MCP shows failed/not connected | New session; Burp running with the MCP extension listening on 9876; `type` is `sse` (not stdio) with the URL set |

--- a/engine/skill_map.py
+++ b/engine/skill_map.py
@@ -23,9 +23,10 @@ def _resolve_skills_dir():
     Resolution order:
       1. $CBH_SKILLS_DIR — explicit override (e.g. a non-standard plugin cache path).
       2. skills/ shipped next to the engine — works for both a repo checkout and a
-         Claude Code plugin install (the whole bundle lives in the plugin cache, so
-         engine/ and skills/ stay siblings there too).
+         Claude Code / ZCode plugin install (the whole bundle lives in the plugin
+         cache, so engine/ and skills/ stay siblings there too).
       3. ~/.claude/skills — the target of the scripts/install.sh copy method.
+      4. ~/.zcode/skills — the target of scripts/install.sh --zcode (ZCode Agent).
     """
     env = os.environ.get("CBH_SKILLS_DIR")
     if env:
@@ -35,7 +36,9 @@ def _resolve_skills_dir():
     )
     if os.path.isdir(bundled):
         return bundled
-    return os.path.expanduser("~/.claude/skills")
+    if os.path.isdir(os.path.expanduser("~/.claude/skills")):
+        return os.path.expanduser("~/.claude/skills")
+    return os.path.expanduser("~/.zcode/skills")
 
 
 SKILLS_DIR = _resolve_skills_dir()

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -8,7 +8,8 @@ number didn't get updated along with the rest (see the 71/48/24 stale-count
 fixes). This script computes the real counts from skills/ and commands/ on
 disk, then checks every doc location that asserts one of those numbers in
 prose, plus two places where a count is derived by summing a table/section
-breakdown.
+breakdown, plus a sanity check on the ZCode plugin manifest (must parse, name
+must match ZCode's pattern, component dirs and mcpServers entries must resolve).
 
 It deliberately does NOT try to reconcile every document's bespoke
 sub-categorization (e.g. docs/architecture.md's narrower "enterprise-platform"
@@ -24,6 +25,7 @@ Stdlib only — no pip install needed in CI.
 Usage:
     python3 scripts/check_doc_counts.py
 """
+import json
 import os
 import re
 import sys
@@ -125,6 +127,33 @@ def check_catalog_section_sum(errors, actual):
         errors.append(f"docs/skills.md: section headers sum to {total}, actual total is {actual['total']}")
 
 
+def check_zcode_manifest(errors):
+    """The ZCode plugin manifest must parse and point at real components —
+    ZCode loads it directly from the repo, so rot breaks the plugin install."""
+    path = os.path.join(REPO, ".zcode-plugin", "plugin.json")
+    try:
+        with open(path, encoding="utf-8") as fh:
+            manifest = json.load(fh)
+    except FileNotFoundError:
+        errors.append(".zcode-plugin/plugin.json missing — the ZCode plugin install breaks")
+        return
+    except ValueError as e:
+        errors.append(f".zcode-plugin/plugin.json is not valid JSON: {e}")
+        return
+    name = manifest.get("name", "")
+    if not re.match(r"^[a-z0-9][a-z0-9._-]{0,127}$", name):
+        errors.append(f".zcode-plugin/plugin.json: name '{name}' fails ZCode's plugin-name pattern")
+    for field in ("skills", "commands"):
+        val = manifest.get(field)
+        if isinstance(val, str) and not os.path.isdir(os.path.join(REPO, val)):
+            errors.append(f".zcode-plugin/plugin.json: {field} '{val}' is not a directory")
+    mcp = manifest.get("mcpServers")
+    if isinstance(mcp, dict):
+        for srv, defn in mcp.items():
+            if not isinstance(defn, dict) or not (defn.get("command") or defn.get("url")):
+                errors.append(f".zcode-plugin/plugin.json: mcpServers.{srv} needs a command or url")
+
+
 def main():
     total, hunt = count_skills()
     commands = count_commands()
@@ -133,12 +162,13 @@ def main():
     errors = check_assertions(actual)
     check_readme_table_sum(errors, actual)
     check_catalog_section_sum(errors, actual)
+    check_zcode_manifest(errors)
 
     for e in errors:
         print(f"::error:: {e}" if os.environ.get("GITHUB_ACTIONS") else f"ERROR {e}")
 
     print(f"\nGround truth: {total} skills ({hunt} hunt-*), {commands} slash commands.")
-    print(f"Checked {len(CHECKS)} doc assertions + 2 structural sums: {len(errors)} error(s).")
+    print(f"Checked {len(CHECKS)} doc assertions + 3 structural checks: {len(errors)} error(s).")
     return 1 if errors else 0
 
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -15,12 +15,18 @@
 # NOT port; other harnesses get the knowledge, not the orchestration):
 #   -Agents        force-copy skills -> ~\.agents\skills\  (Codex; OpenCode reads ~\.claude)
 #   -Hermes        force-copy skills -> ~\.hermes\skills\   (Hermes Agent)
+#   -Zcode         copy skills + commands -> ~\.zcode\ for ZCode Agent (reads user-scope
+#                  slash commands as well as skills; plugin install via the marketplace is
+#                  the primary route, see docs/zcode.md. Uninstall of this copy path is
+#                  manual.)
 #   -All           DETECT installed harnesses and install to each: Claude always, ~\.agents
-#                  if Codex is present, ~\.hermes if Hermes is present. With -BurpMcp it
-#                  wires Burp only into the detected harnesses. (-Agents/-Hermes still
-#                  force a path regardless of detection.)
+#                  if Codex is present, ~\.hermes if Hermes is present, ~\.zcode if ZCode
+#                  is present. With -BurpMcp it wires Burp only into the detected
+#                  harnesses. (-Agents/-Hermes/-Zcode still force a path regardless
+#                  of detection.)
 #   -BurpMcp       wire your existing Burp MCP server into the selected harnesses'
-#                  configs (opt-in; backs up each config first; uses python)
+#                  configs (opt-in; backs up each config first; uses python; for ZCode
+#                  writes the recommended SSE entry)
 #   -NormalizeFrontmatter
 #                  strip non-standard keys (sources/report_count) from the NON-Claude
 #                  copies — only needed if a harness rejects unknown frontmatter keys
@@ -39,6 +45,7 @@
 param(
     [switch] $Agents,
     [switch] $Hermes,
+    [switch] $Zcode,
     [switch] $All,
     [switch] $BurpMcp,
     [switch] $NormalizeFrontmatter,
@@ -154,10 +161,10 @@ function Install-Skills([string] $Dest, [string] $Label) {
 }
 
 # --- flag plumbing -----------------------------------------------------
-$DO_AGENTS = [bool]$Agents; $DO_HERMES = [bool]$Hermes; $DO_MCP = [bool]$BurpMcp
+$DO_AGENTS = [bool]$Agents; $DO_HERMES = [bool]$Hermes; $DO_ZCODE = [bool]$Zcode; $DO_MCP = [bool]$BurpMcp
 $NORMALIZE = [bool]$NormalizeFrontmatter; $DETECT = [bool]$All
 $DO_UNINSTALL = [bool]$Uninstall; $NO_PROFILE = [bool]$NoProfile
-$HAS_CLAUDE = $false; $HAS_OPENCODE = $false; $HAS_CODEX = $false; $HAS_HERMES = $false
+$HAS_CLAUDE = $false; $HAS_OPENCODE = $false; $HAS_CODEX = $false; $HAS_HERMES = $false; $HAS_ZCODE = $false
 
 # --- Uninstall ---------------------------------------------------------
 function Uninstall-Bundle {
@@ -214,17 +221,20 @@ if ($DETECT) {
     if ((Get-Command opencode -ErrorAction SilentlyContinue) -or (Test-Path (Join-Path $HOME '.config\opencode'))) { $HAS_OPENCODE = $true }
     if ((Get-Command codex -ErrorAction SilentlyContinue) -or (Test-Path (Join-Path $HOME '.codex'))) { $HAS_CODEX = $true }
     if ((Get-Command hermes -ErrorAction SilentlyContinue) -or (Test-Path (Join-Path $HOME '.hermes'))) { $HAS_HERMES = $true }
+    if ((Get-Command zcode -ErrorAction SilentlyContinue) -or (Test-Path (Join-Path $HOME '.zcode'))) { $HAS_ZCODE = $true }
     Write-Host "Detecting installed harnesses:"
     if ($HAS_CLAUDE)   { Write-Host "  + Claude Code   -> ~\.claude\skills" }
     if ($HAS_OPENCODE) { Write-Host "  + OpenCode      -> reads ~\.claude\skills (MCP wired separately)" }
     if ($HAS_CODEX)    { Write-Host "  + Codex CLI     -> ~\.agents\skills" }
     if ($HAS_HERMES)   { Write-Host "  + Hermes Agent  -> ~\.hermes\skills" }
-    if (-not ($HAS_OPENCODE -or $HAS_CODEX -or $HAS_HERMES)) {
-        Write-Host "  (only Claude Code detected -- installing there. Force others with -Agents / -Hermes.)"
+    if ($HAS_ZCODE)    { Write-Host "  + ZCode Agent   -> ~\.zcode\skills + ~\.zcode\commands" }
+    if (-not ($HAS_OPENCODE -or $HAS_CODEX -or $HAS_HERMES -or $HAS_ZCODE)) {
+        Write-Host "  (only Claude Code detected -- installing there. Force others with -Agents / -Hermes / -Zcode.)"
     }
     Write-Host ''
     if ($HAS_CODEX)  { $DO_AGENTS = $true }
     if ($HAS_HERMES) { $DO_HERMES = $true }
+    if ($HAS_ZCODE)  { $DO_ZCODE = $true }
 }
 
 if (-not (Test-Path -LiteralPath $SkillsSource -PathType Container)) {
@@ -234,7 +244,7 @@ $skillCount = (Get-ChildItem -LiteralPath $SkillsSource -Directory).Count
 
 # --- Claude Code (always): skills + commands + hunt.ps1 ----------------
 Write-Host "Installing Claude-BugHunter bundle from $RepoDir"
-if ($DO_AGENTS -or $DO_HERMES) { Write-Host "(multi-harness mode)" }
+if ($DO_AGENTS -or $DO_HERMES -or $DO_ZCODE) { Write-Host "(multi-harness mode)" }
 Write-Host ''
 
 Install-Skills (Join-Path $HOME '.claude\skills') 'skills'
@@ -307,14 +317,33 @@ Write-Host "  + Install manifest ($($entries.Count) entries) -> $Manifest"
 Write-Host "    Uninstall later with:  pwsh ./scripts/install.ps1 -Uninstall"
 Write-Host ''
 
-# --- extra harness targets (skills only) ------------------------------
-if ($DO_AGENTS) {
-    Install-Skills (Join-Path $HOME '.agents\skills') 'agents'
+# Copy commands/*.md into <dest>, backing up changed files OUTSIDE the loading path.
+function Install-Commands([string] $Dest, [string] $Label) {
+    if (-not (Test-Path -LiteralPath $CommandsSrc)) { return }
+    if (-not (Test-Path -LiteralPath $Dest)) { New-Item -ItemType Directory -Force -Path $Dest | Out-Null }
+    Write-Host "Commands ->  $Dest   ($Label)"
+    foreach ($f in (Get-ChildItem -LiteralPath $CommandsSrc -Filter *.md -File)) {
+        $dst = Join-Path $Dest $f.Name
+        if (Test-Path -LiteralPath $dst) {
+            if (Test-FilesEqual $f.FullName $dst) { continue }
+            $bk = Join-Path $BackupDest $Label
+            New-Item -ItemType Directory -Force -Path $bk | Out-Null
+            Move-Item -LiteralPath $dst (Join-Path $bk $f.Name) -Force
+        }
+        Copy-Item -LiteralPath $f.FullName -Destination $dst -Force
+    }
+    Write-Host "  + commands installed"
+    Write-Host ''
+}
+
+# Guard a copied skills tree against the 1024-char description limit that Codex
+# (hard reject) and ZCode (whole skill dropped) enforce. Drift insurance only —
+# the repo is linted to stay under the limit. $StripExtras removes non-standard
+# frontmatter keys (Codex-only, -NormalizeFrontmatter).
+function Invoke-DescGuard([string] $Dest, [bool] $StripExtras) {
     $py = Get-Python
-    if ($py) {
-        $limit = 1024
-        # Inline truncation script (ports the bash heredoc verbatim).
-        $trunc = @"
+    if (-not $py) { return }
+    $trunc = @"
 import os, re, sys
 root, strip_extra = sys.argv[1], sys.argv[2] == '1'
 LIMIT = 1024
@@ -334,7 +363,7 @@ for name in sorted(os.listdir(root)):
                 cut = inner[:LIMIT - 2].rsplit(' ', 1)[0].rstrip(' ,;:_-')
                 line = 'description: "' + cut + '..."'
                 changed = True
-                print('    truncated ' + name + ' description ' + str(len(inner)) + '->' + str(len(cut)+1) + ' (Codex 1024 limit)')
+                print('    truncated ' + name + ' description ' + str(len(inner)) + '->' + str(len(cut)+1) + ' (1024-char limit)')
         if strip_extra and i < 12 and re.match(r'^(sources|report_count):\s', line):
             changed = True
             continue
@@ -342,15 +371,29 @@ for name in sorted(os.listdir(root)):
     if changed:
         open(p, 'w', encoding='utf-8').write('\n'.join(out))
 "@
-        $truncFile = Join-Path $env:TEMP 'cbh_trunc.py'
-        Write-HuntFile $truncFile $trunc
-        $pyExe = $py[0]
-        $pyRest = @($py[1..($py.Length - 1)]) + @($truncFile, (Join-Path $HOME '.agents\skills'), "$(if ($NORMALIZE) { '1' } else { '0' })")
-        & $pyExe $pyRest
-        Remove-Item -LiteralPath $truncFile -Force -ErrorAction SilentlyContinue
-    }
+    $truncFile = Join-Path $env:TEMP 'cbh_trunc.py'
+    Write-HuntFile $truncFile $trunc
+    $pyExe = $py[0]
+    $pyRest = @($py[1..($py.Length - 1)]) + @($truncFile, $Dest, "$(if ($StripExtras) { '1' } else { '0' })")
+    & $pyExe $pyRest
+    Remove-Item -LiteralPath $truncFile -Force -ErrorAction SilentlyContinue
+}
+
+# --- extra harness targets (skills only) ------------------------------
+if ($DO_AGENTS) {
+    Install-Skills (Join-Path $HOME '.agents\skills') 'agents'
+    Invoke-DescGuard (Join-Path $HOME '.agents\skills') $NORMALIZE
 }
 if ($DO_HERMES) { Install-Skills (Join-Path $HOME '.hermes\skills') 'hermes' }
+
+# ZCode Agent — skills AND commands (it reads both at user scope). The plugin
+# marketplace install (docs/zcode.md) is the primary route; this is the copy
+# alternative. Not tracked by the ~\.claude uninstall manifest.
+if ($DO_ZCODE) {
+    Install-Skills (Join-Path $HOME '.zcode\skills') 'zcode-skills'
+    Install-Commands (Join-Path $HOME '.zcode\commands') 'zcode-commands'
+    Invoke-DescGuard (Join-Path $HOME '.zcode\skills') $false
+}
 
 # --- opt-in Burp MCP wiring -------------------------------------------
 if ($DO_MCP) {
@@ -359,12 +402,14 @@ if ($DO_MCP) {
         if ($HAS_OPENCODE) { $mcpTargets += '--opencode' }
         if ($HAS_CODEX)    { $mcpTargets += '--codex' }
         if ($HAS_HERMES)   { $mcpTargets += '--hermes' }
+        if ($HAS_ZCODE)    { $mcpTargets += '--zcode' }
     } else {
         if ($DO_AGENTS) { $mcpTargets += '--opencode'; $mcpTargets += '--codex' }
         if ($DO_HERMES) { $mcpTargets += '--hermes' }
+        if ($DO_ZCODE)  { $mcpTargets += '--zcode' }
     }
     if ($mcpTargets.Count -eq 0) {
-        Write-Host "  ! -BurpMcp found no non-Claude harness (none detected, no -Agents/-Hermes). Skipping."
+        Write-Host "  ! -BurpMcp found no non-Claude harness (none detected, no -Agents/-Hermes/-Zcode). Skipping."
     } else {
         $py = Get-Python
         if ($py) {
@@ -391,11 +436,15 @@ Write-Host ''
 Write-Host "Claude Code:   $(Join-Path $HOME '.claude\skills')  (+ commands, hunt.ps1)"
 if ($DO_AGENTS) { Write-Host "Codex+OpenCode: $(Join-Path $HOME '.agents\skills')" }
 if ($DO_HERMES) { Write-Host "Hermes Agent:  $(Join-Path $HOME '.hermes\skills')" }
+if ($DO_ZCODE) {
+    Write-Host "ZCode Agent:   $(Join-Path $HOME '.zcode\skills') + $(Join-Path $HOME '.zcode\commands')"
+    Write-Host "               (plugin install via marketplace also available -- docs/zcode.md)"
+}
 if (Test-Path -LiteralPath $BackupDest) { Write-Host "Backups:       $BackupDest  (outside loading paths)" }
 Write-Host ''
-if (-not $DETECT -and -not $DO_AGENTS -and -not $DO_HERMES) {
-    Write-Host "Other harnesses?  pwsh ./scripts/install.ps1 -All   (auto-detects Codex / OpenCode / Hermes)"
-    Write-Host "See also: docs/multi-harness.md"
+if (-not $DETECT -and -not $DO_AGENTS -and -not $DO_HERMES -and -not $DO_ZCODE) {
+    Write-Host "Other harnesses?  pwsh ./scripts/install.ps1 -All   (auto-detects Codex / OpenCode / Hermes / ZCode)"
+    Write-Host "See also: docs/multi-harness.md, docs/zcode.md"
 }
 Write-Host ''
 Write-Host "Next: open a new PowerShell window (or '. `$PROFILE') and try:  hunt acme-test"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,12 +13,18 @@
 # NOT port; other harnesses get the knowledge, not the orchestration):
 #   --agents    force-copy skills → ~/.agents/skills/  (Codex; OpenCode reads ~/.claude)
 #   --hermes    force-copy skills → ~/.hermes/skills/   (Hermes Agent)
+#   --zcode     copy skills + commands → ~/.zcode/  (ZCode Agent — reads user-scope
+#               slash commands as well as skills; plugin install via the marketplace is
+#               the primary route, see docs/zcode.md. Uninstall of this copy path is
+#               manual: rm -rf ~/.zcode/skills/<name> ~/.zcode/commands/<cmd>.md)
 #   --all       DETECT installed harnesses and install to each: Claude always, ~/.agents
-#               if Codex is present, ~/.hermes if Hermes is present. With --burp-mcp it
-#               wires Burp only into the detected harnesses. (--agents/--hermes still
-#               force a path regardless of detection.)
+#               if Codex is present, ~/.hermes if Hermes is present, ~/.zcode if ZCode
+#               is present. With --burp-mcp it wires Burp only into the detected
+#               harnesses. (--agents/--hermes/--zcode still force a path regardless
+#               of detection.)
 #   --burp-mcp  wire your existing Burp MCP server into the selected harnesses'
-#               configs (opt-in; backs up each config first; uses python3)
+#               configs (opt-in; backs up each config first; uses python3; for ZCode
+#               writes the recommended SSE entry)
 #   --normalize-frontmatter
 #               strip non-standard keys (sources/report_count) from the NON-Claude
 #               copies — only needed if a harness rejects unknown frontmatter keys
@@ -52,12 +58,13 @@ MANIFEST="$MANIFEST_DIR/$BUNDLE_NAME.txt"
 
 usage() { sed -n '2,/^# ===/p' "$0" | sed 's/^#\{0,1\} \{0,1\}//'; }
 
-DO_AGENTS=0; DO_HERMES=0; DO_MCP=0; NORMALIZE=0; DETECT=0; DO_UNINSTALL=0; NO_SHELL=0
-HAS_CLAUDE=0; HAS_OPENCODE=0; HAS_CODEX=0; HAS_HERMES=0
+DO_AGENTS=0; DO_HERMES=0; DO_ZCODE=0; DO_MCP=0; NORMALIZE=0; DETECT=0; DO_UNINSTALL=0; NO_SHELL=0
+HAS_CLAUDE=0; HAS_OPENCODE=0; HAS_CODEX=0; HAS_HERMES=0; HAS_ZCODE=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --agents) DO_AGENTS=1 ;;
     --hermes) DO_HERMES=1 ;;
+    --zcode)  DO_ZCODE=1 ;;
     --all)    DETECT=1 ;;
     --burp-mcp) DO_MCP=1 ;;
     --normalize-frontmatter) NORMALIZE=1 ;;
@@ -119,17 +126,20 @@ if [ "$DETECT" = "1" ]; then
   if command -v opencode >/dev/null 2>&1 || [ -d "$HOME/.config/opencode" ]; then HAS_OPENCODE=1; fi
   if command -v codex    >/dev/null 2>&1 || [ -d "$HOME/.codex" ];           then HAS_CODEX=1; fi
   if command -v hermes   >/dev/null 2>&1 || [ -d "$HOME/.hermes" ];          then HAS_HERMES=1; fi
+  if command -v zcode    >/dev/null 2>&1 || [ -d "$HOME/.zcode" ];           then HAS_ZCODE=1; fi
   echo "Detecting installed harnesses:"
   if [ "$HAS_CLAUDE"   = "1" ]; then echo "  ✓ Claude Code   → ~/.claude/skills"; fi
   if [ "$HAS_OPENCODE" = "1" ]; then echo "  ✓ OpenCode      → reads ~/.claude/skills (MCP wired separately)"; fi
   if [ "$HAS_CODEX"    = "1" ]; then echo "  ✓ Codex CLI     → ~/.agents/skills"; fi
   if [ "$HAS_HERMES"   = "1" ]; then echo "  ✓ Hermes Agent  → ~/.hermes/skills"; fi
-  if [ "$HAS_OPENCODE" = "0" ] && [ "$HAS_CODEX" = "0" ] && [ "$HAS_HERMES" = "0" ]; then
-    echo "  (only Claude Code detected — installing there. Force others with --agents / --hermes.)"
+  if [ "$HAS_ZCODE"    = "1" ]; then echo "  ✓ ZCode Agent   → ~/.zcode/skills + ~/.zcode/commands"; fi
+  if [ "$HAS_OPENCODE" = "0" ] && [ "$HAS_CODEX" = "0" ] && [ "$HAS_HERMES" = "0" ] && [ "$HAS_ZCODE" = "0" ]; then
+    echo "  (only Claude Code detected — installing there. Force others with --agents / --hermes / --zcode.)"
   fi
   echo ""
   if [ "$HAS_CODEX"  = "1" ]; then DO_AGENTS=1; fi
   if [ "$HAS_HERMES" = "1" ]; then DO_HERMES=1; fi
+  if [ "$HAS_ZCODE"  = "1" ]; then DO_ZCODE=1; fi
 fi
 
 SKILL_COUNT="$(find "$REPO_DIR/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
@@ -157,8 +167,29 @@ install_skills() {
   echo ""
 }
 
+# Copy commands/*.md into <dest>, backing up changed files OUTSIDE the loading
+# path. $2 is a label used for the backup subfolder + logging.
+install_commands() {
+  local dest="$1" label="$2" cmd_file cmd_name
+  [ -d "$REPO_DIR/commands" ] || return 0
+  mkdir -p "$dest"
+  echo "Commands →  $dest   ($label)"
+  for cmd_file in "$REPO_DIR/commands"/*.md; do
+    [ -e "$cmd_file" ] || continue
+    cmd_name="$(basename "$cmd_file")"
+    if [ -f "$dest/$cmd_name" ] && [ ! -L "$dest/$cmd_name" ]; then
+      if cmp -s "$cmd_file" "$dest/$cmd_name"; then continue; fi
+      mkdir -p "$BACKUP_DEST/$label"
+      mv "$dest/$cmd_name" "$BACKUP_DEST/$label/$cmd_name"
+    fi
+    cp "$cmd_file" "$dest/$cmd_name"
+  done
+  echo "  ✓ commands installed"
+  echo ""
+}
+
 echo "Installing Claude-BugHunter bundle from $REPO_DIR"
-if [ "$DO_AGENTS" = "1" ] || [ "$DO_HERMES" = "1" ]; then echo "(multi-harness mode)"; fi
+if [ "$DO_AGENTS" = "1" ] || [ "$DO_HERMES" = "1" ] || [ "$DO_ZCODE" = "1" ]; then echo "(multi-harness mode)"; fi
 echo ""
 
 # === Claude Code (always) — skills + commands + hunt.sh ===
@@ -232,14 +263,14 @@ echo "    Uninstall later with:  bash scripts/install.sh --uninstall"
 echo ""
 
 # === Extra harness targets (skills only) ===
-if [ "$DO_AGENTS" = "1" ]; then
-  install_skills "$HOME/.agents/skills" "agents"
-  # Codex (which reads ~/.agents/skills) HARD-rejects descriptions > 1024 chars.
-  # Auto-truncate over-length descriptions in THIS copy only — ~/.claude and
-  # ~/.hermes keep full descriptions. Optional --normalize-frontmatter also strips
-  # non-standard keys (sources/report_count). Python3 only; skipped if absent.
-  if command -v python3 >/dev/null 2>&1; then
-    python3 - "$HOME/.agents/skills" "$NORMALIZE" <<'PY'
+# Guard a copied skills tree against the 1024-char description limit that Codex
+# (hard reject) and ZCode (whole skill dropped) enforce. The repo is linted to
+# stay under the limit; this pass is drift insurance for the copies. Optional
+# strip of non-standard frontmatter keys is Codex-only (--normalize-frontmatter).
+guard_desc_limit() {
+  local dest="$1" strip="$2"
+  command -v python3 >/dev/null 2>&1 || return 0
+  python3 - "$dest" "$strip" <<'PY'
 import os, re, sys
 root, strip_extra = sys.argv[1], sys.argv[2] == "1"
 LIMIT = 1024
@@ -260,7 +291,7 @@ for name in sorted(os.listdir(root)):
                 cut = inner[:LIMIT - 2].rsplit(" ", 1)[0].rstrip(" ,;:—-")
                 line = 'description: "' + cut + '…"'
                 changed = True
-                print(f"    ✂ truncated {name} description {len(inner)}→{len(cut)+1} (Codex 1024 limit)")
+                print(f"    ✂ truncated {name} description {len(inner)}→{len(cut)+1} (1024-char limit)")
         if strip_extra and i < 12 and re.match(r'^(sources|report_count):\s', line):
             changed = True
             continue
@@ -268,9 +299,21 @@ for name in sorted(os.listdir(root)):
     if changed:
         open(p, "w", encoding="utf-8").write("\n".join(out))
 PY
-  fi
+}
+if [ "$DO_AGENTS" = "1" ]; then
+  install_skills "$HOME/.agents/skills" "agents"
+  guard_desc_limit "$HOME/.agents/skills" "$NORMALIZE"
 fi
 if [ "$DO_HERMES" = "1" ]; then install_skills "$HOME/.hermes/skills" "hermes"; fi
+
+# ZCode Agent — skills AND commands (it reads both at user scope). The plugin
+# marketplace install (docs/zcode.md) is the primary route; this is the copy
+# alternative. Not tracked by the ~/.claude uninstall manifest.
+if [ "$DO_ZCODE" = "1" ]; then
+  install_skills "$HOME/.zcode/skills" "zcode-skills"
+  install_commands "$HOME/.zcode/commands" "zcode-commands"
+  guard_desc_limit "$HOME/.zcode/skills" "0"
+fi
 
 # === Opt-in: wire the existing Burp MCP into the selected harnesses ===
 if [ "$DO_MCP" = "1" ]; then
@@ -280,13 +323,15 @@ if [ "$DO_MCP" = "1" ]; then
     if [ "$HAS_OPENCODE" = "1" ]; then MCP_TARGETS="$MCP_TARGETS --opencode"; fi
     if [ "$HAS_CODEX"    = "1" ]; then MCP_TARGETS="$MCP_TARGETS --codex"; fi
     if [ "$HAS_HERMES"   = "1" ]; then MCP_TARGETS="$MCP_TARGETS --hermes"; fi
+    if [ "$HAS_ZCODE"    = "1" ]; then MCP_TARGETS="$MCP_TARGETS --zcode"; fi
   else
     # explicit-flag mode
     if [ "$DO_AGENTS" = "1" ]; then MCP_TARGETS="$MCP_TARGETS --opencode --codex"; fi
     if [ "$DO_HERMES" = "1" ]; then MCP_TARGETS="$MCP_TARGETS --hermes"; fi
+    if [ "$DO_ZCODE"  = "1" ]; then MCP_TARGETS="$MCP_TARGETS --zcode"; fi
   fi
   if [ -z "$MCP_TARGETS" ]; then
-    echo "  ⚠ --burp-mcp found no non-Claude harness (none detected, no --agents/--hermes). Skipping."
+    echo "  ⚠ --burp-mcp found no non-Claude harness (none detected, no --agents/--hermes/--zcode). Skipping."
   elif command -v python3 >/dev/null 2>&1; then
     # shellcheck disable=SC2086
     python3 "$REPO_DIR/scripts/setup_harness_mcp.py" $MCP_TARGETS || \
@@ -304,11 +349,15 @@ echo ""
 echo "Claude Code:   $HOME/.claude/skills  (+ commands, hunt.sh)"
 if [ "$DO_AGENTS" = "1" ]; then echo "Codex+OpenCode: $HOME/.agents/skills"; fi
 if [ "$DO_HERMES" = "1" ]; then echo "Hermes Agent:  $HOME/.hermes/skills"; fi
+if [ "$DO_ZCODE" = "1" ]; then
+  echo "ZCode Agent:   $HOME/.zcode/skills + $HOME/.zcode/commands"
+  echo "               (plugin install via marketplace also available — docs/zcode.md)"
+fi
 if [ -d "$BACKUP_DEST" ]; then echo "Backups:       $BACKUP_DEST  (outside loading paths)"; fi
 echo ""
-if [ "$DETECT" = "0" ] && [ "$DO_AGENTS" = "0" ] && [ "$DO_HERMES" = "0" ]; then
-  echo "Other harnesses?  bash scripts/install.sh --all   (auto-detects Codex / OpenCode / Hermes)"
-  echo "See also: docs/multi-harness.md"
+if [ "$DETECT" = "0" ] && [ "$DO_AGENTS" = "0" ] && [ "$DO_HERMES" = "0" ] && [ "$DO_ZCODE" = "0" ]; then
+  echo "Other harnesses?  bash scripts/install.sh --all   (auto-detects Codex / OpenCode / Hermes / ZCode)"
+  echo "See also: docs/multi-harness.md, docs/zcode.md"
 fi
 echo ""
 echo "Next: open a new terminal (or 'source $SHELL_RC') and try:  hunt acme-test"

--- a/scripts/lint_skills.py
+++ b/scripts/lint_skills.py
@@ -57,6 +57,8 @@ SECRET_ALLOW = re.compile(
 # Intentional kitchen-sink router/aggregator skills whose descriptions deliberately
 # exceed the per-skill limit (they route to everything). Over-length is a warning,
 # not an error, for these. Do NOT add new skills here — write focused descriptions.
+# Strict harnesses (Codex, ZCode) get auto-truncated COPIES from the installer
+# (install.sh --agents/--zcode); the repo keeps the full trigger surface.
 DESC_LIMIT_GRANDFATHERED = {"bug-bounty", "bb-local-toolkit", "osint-methodology"}
 
 WORD_RE = re.compile(r"[a-z0-9]+")
@@ -166,7 +168,8 @@ def lint_skill(skill_dir, denylist):
         errors.append(f"{name}: frontmatter missing `description`")
     elif len(desc) > MAX_DESC:
         msg = (f"{name}: description {len(desc)} chars > {MAX_DESC} limit "
-               f"(Codex rejects >1024; install.sh --agents auto-truncates the Codex copy)")
+               "(Codex rejects >1024 and ZCode drops the skill; install.sh --agents/--zcode "
+               "auto-truncates those copies)")
         (warnings if name in DESC_LIMIT_GRANDFATHERED else errors).append(msg)
     elif len(desc) < 40:
         warnings.append(f"{name}: description very short ({len(desc)} chars) — weak trigger surface")

--- a/scripts/setup_harness_mcp.py
+++ b/scripts/setup_harness_mcp.py
@@ -7,35 +7,35 @@ Code already uses — we never invent one) and writes the equivalent into each
 selected harness's config, backing up the file first. Idempotent.
 
 Usage:
-    python3 scripts/setup_harness_mcp.py [--opencode] [--codex] [--hermes] [--dry-run]
-    # optional overrides if auto-discovery fails:
-    python3 scripts/setup_harness_mcp.py --opencode --command java --arg -jar --arg /path/mcp-proxy-all.jar --arg --sse-url --arg http://127.0.0.1:9876
+    python3 scripts/setup_harness_mcp.py [--opencode] [--codex] [--hermes] [--zcode] [--dry-run]
+    # --zcode registers the Burp MCP extension's SSE endpoint (no stdio discovery needed):
+    python3 scripts/setup_harness_mcp.py --zcode [--sse-url http://127.0.0.1:9876]
+    # optional overrides if auto-discovery fails (stdio harnesses only):
+    python3 scripts/setup_harness_mcp.py --opencode --command java --arg=-jar --arg /path/mcp-proxy-all.jar --arg=--sse-url --arg http://127.0.0.1:9876
 
 Schema notes (verified against each tool's docs, mid-2026):
   - OpenCode  ~/.config/opencode/opencode.json  →  mcp.<name> = {type:"local", command:[...], enabled:true}   (JSON — written here)
   - Codex     ~/.codex/config.toml              →  [mcp_servers.<name>] command/args/env                      (TOML — appended here)
   - Hermes    ~/.hermes/config.yaml             →  MCP block (schema not independently verified) — we PRINT the
               command + the Hermes MCP guide instead of blind-writing YAML.
+  - ZCode     ~/.zcode/cli/config.json          →  mcp.servers.<name> = {type:"sse", url:"http://127.0.0.1:9876",
+              enabled:true}  — the recommended (and simpler) setup. (JSON — written here;
+              nested mcp.servers, NOT top-level mcpServers.)
 """
 import argparse, json, os, shutil, sys, time
 
 CLAUDE_JSON = os.path.expanduser("~/.claude.json")
+ZCODE_JSON = os.path.expanduser("~/.zcode/cli/config.json")
 
 
-def discover_burp():
-    """Return (command:str, args:list[str], env:dict) for the 'burp' MCP server from ~/.claude.json."""
-    if not os.path.isfile(CLAUDE_JSON):
-        return None
-    try:
-        data = json.load(open(CLAUDE_JSON, encoding="utf-8"))
-    except Exception:
-        return None
+def _find_burp_in(data):
+    """Return the first 'burp'-named stdio server definition anywhere in `data`, or None."""
     hits = []
 
     def walk(o):
         if isinstance(o, dict):
             for k, v in o.items():
-                if k in ("mcpServers", "mcp_servers", "mcp") and isinstance(v, dict):
+                if k in ("mcpServers", "mcp_servers", "mcp", "servers") and isinstance(v, dict):
                     for name, defn in v.items():
                         if "burp" in name.lower() and isinstance(defn, dict) and defn.get("command"):
                             hits.append(defn)
@@ -45,10 +45,26 @@ def discover_burp():
                 walk(x)
 
     walk(data)
-    if not hits:
-        return None
-    d = hits[0]
-    return d.get("command"), list(d.get("args", [])), dict(d.get("env", {}) or {})
+    return hits[0] if hits else None
+
+
+def discover_burp():
+    """Return (command:str, args:list[str], env:dict) for the 'burp' MCP server.
+
+    Looks in ~/.claude.json first (Claude Code), then ~/.zcode/cli/config.json
+    (ZCode Agent, mcp.servers) — whichever harness already has Burp wired.
+    """
+    for path in (CLAUDE_JSON, ZCODE_JSON):
+        if not os.path.isfile(path):
+            continue
+        try:
+            data = json.load(open(path, encoding="utf-8"))
+        except Exception:
+            continue
+        d = _find_burp_in(data)
+        if d:
+            return d.get("command"), list(d.get("args", [])), dict(d.get("env", {}) or {})
+    return None
 
 
 def backup(path):
@@ -153,37 +169,80 @@ def write_hermes(cmd, args, env, dry):
     print("  ✓ Hermes burp MCP written.")
 
 
+def write_zcode(sse_url, dry):
+    # ZCode user config: ~/.zcode/cli/config.json with NESTED mcp.servers.<name>
+    # (a top-level mcpServers key is NOT read there). The file also holds hooks,
+    # plugin state, etc., so read-merge-write — never overwrite wholesale.
+    path = ZCODE_JSON
+    cfg = {}
+    if os.path.isfile(path):
+        try:
+            cfg = json.load(open(path, encoding="utf-8"))
+        except Exception:
+            print(f"  ✗ ZCode: {path} is not valid JSON — skipping (fix it or edit manually).")
+            return
+    entry = {"type": "sse", "url": sse_url, "enabled": True}
+    servers = cfg.setdefault("mcp", {}).setdefault("servers", {})
+    # Any existing server already on this SSE endpoint (under any name) wins —
+    # never register a second connection to the same Burp extension.
+    for srv_name, srv in servers.items():
+        if isinstance(srv, dict) and srv.get("url") == sse_url:
+            print(f"  = ZCode: server '{srv_name}' already uses {sse_url} (no change).")
+            return
+    if servers.get("burp") == entry:
+        print("  = ZCode: mcp.servers.burp already configured (no change).")
+        return
+    servers["burp"] = entry
+    print(f"  → ZCode: set mcp.servers.burp = SSE {sse_url} in {path}")
+    if dry:
+        print("      [dry-run] " + json.dumps(entry))
+        return
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    backup(path)
+    json.dump(cfg, open(path, "w", encoding="utf-8"), indent=2)
+    open(path, "a").write("\n")
+    print("  ✓ ZCode burp MCP written.  Start a NEW ZCode session (Burp running, MCP extension listening) and check Settings → MCP.")
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--opencode", action="store_true")
     ap.add_argument("--codex", action="store_true")
     ap.add_argument("--hermes", action="store_true")
+    ap.add_argument("--zcode", action="store_true")
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--command")
     ap.add_argument("--arg", action="append", default=[])
+    ap.add_argument("--sse-url", default="http://127.0.0.1:9876",
+                    help="Burp MCP extension SSE endpoint used by --zcode (default: %(default)s)")
     a = ap.parse_args()
 
-    if a.command:
-        cmd, args, env = a.command, a.arg, {}
-    else:
-        found = discover_burp()
-        if not found:
-            print("✗ Could not find a 'burp' MCP server in ~/.claude.json.")
-            print("  Pass it explicitly, e.g.:")
-            print("    --command java --arg -jar --arg ~/.BurpSuite/mcp-proxy/mcp-proxy-all.jar --arg --sse-url --arg http://127.0.0.1:9876")
-            return 1
-        cmd, args, env = found
-
-    print(f"Burp MCP source: {cmd} {' '.join(args)}{'  (dry-run)' if a.dry_run else ''}")
-    if not (a.opencode or a.codex or a.hermes):
-        print("Nothing to do — pass --opencode / --codex / --hermes.")
+    stdio_targets = a.opencode or a.codex or a.hermes
+    if not (stdio_targets or a.zcode):
+        print("Nothing to do — pass --opencode / --codex / --hermes / --zcode.")
         return 0
-    if a.opencode:
-        write_opencode(cmd, args, env, a.dry_run)
-    if a.codex:
-        write_codex(cmd, args, env, a.dry_run)
-    if a.hermes:
-        write_hermes(cmd, args, env, a.dry_run)
+
+    if stdio_targets:
+        if a.command:
+            cmd, args, env = a.command, a.arg, {}
+        else:
+            found = discover_burp()
+            if not found:
+                print("✗ Could not find a 'burp' MCP server in ~/.claude.json or ~/.zcode/cli/config.json.")
+                print("  Pass it explicitly, e.g.:")
+                print("    --command java --arg=-jar --arg ~/.BurpSuite/mcp-proxy/mcp-proxy-all.jar --arg=--sse-url --arg http://127.0.0.1:9876")
+                print("  (Or use --zcode to register the SSE endpoint instead.)")
+                return 1
+            cmd, args, env = found
+        print(f"Burp MCP source: {cmd} {' '.join(args)}{'  (dry-run)' if a.dry_run else ''}")
+        if a.opencode:
+            write_opencode(cmd, args, env, a.dry_run)
+        if a.codex:
+            write_codex(cmd, args, env, a.dry_run)
+        if a.hermes:
+            write_hermes(cmd, args, env, a.dry_run)
+    if a.zcode:
+        write_zcode(a.sse_url, a.dry_run)
     return 0
 
 


### PR DESCRIPTION
Adds ZCode Agent as a fifth harness, treated like the rest:

- **Plugin install** — `.zcode-plugin/plugin.json` (ZCode also reads the existing `.claude-plugin/` manifest and marketplace), so skills + slash commands register natively from this repo
- **Copy install** — `install.sh --zcode` / `install.ps1 -Zcode` (skills + commands); `--all` / `-All` detect ZCode
- **Burp MCP** — `setup_harness_mcp.py --zcode` writes the SSE entry (`mcp.servers.burp` → `http://127.0.0.1:9876`) into `~/.zcode/cli/config.json`, with a duplicate-URL guard
- **Strict-limit handling** — copy installers auto-truncate >1024-char descriptions in the `~/.zcode` copy only (same as the Codex copy); repo keeps full descriptions
- **Docs** — new `docs/zcode.md`; README / INSTALL / multi-harness / routing SVG updated; lint message extended

No behavior change for Claude Code, OpenCode, Codex, or Hermes (verified: writer functions byte-identical, truncation logic unchanged, default install path identical).

Tested and working on ZCode: plugin install, slash commands, skills, Burp MCP over SSE.