### PR TITLE
feat(grounding): enforce sources/report_count (GROUNDING_STRICT = True)

### DIFF
--- a/scripts/lint_skills.py
+++ b/scripts/lint_skills.py
@@ -42,8 +42,8 @@ MAX_BODY_LINES = 500
 # Grounding enforcement. Every skill must declare `sources:`; hunt-* skills (built
 # from disclosed reports) must also declare an integer `report_count:` (0 is fine
 # when `sources:` justifies it — e.g. a pattern library or research-derived skill).
-# Phase 4a ships this as WARNINGS while the backfill lands; 4b flips it to errors.
-GROUNDING_STRICT = False
+# Phase 4a shipped this as WARNINGS while the backfill landed; now enforced as errors.
+GROUNDING_STRICT = True
 
 # --- real-secret patterns (kept tight to avoid flagging documented regexes) ---
 SECRET_PATTERNS = [


### PR DESCRIPTION
**Phase 4b — the one-line flip.**

4a (#68) backfilled every skill and shipped the grounding validator in *warn* mode. `main` now reports **0 grounding warnings**, so this flips `GROUNDING_STRICT` to `True`: grounding issues move from warnings to **errors**.

A skill missing `sources:` — or a `hunt-*` skill missing an integer `report_count:` — now **fails CI**.

## Verified
- `lint_skills.py` still **0 errors** on current `main`
- Removing a skill's `sources:` now produces an **ERROR** and exit 1 (CI would fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)