### PR TITLE
docs(readme): stacked sponsor layout (option 1b)

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,16 +290,18 @@ The per-class `hunt-*` skills address gap-zero (*"what should I look for in weba
 <p align="center">
   <a href="https://www.atlascloud.ai/console/coding-plan"><picture>
     <source media="(prefers-color-scheme: dark)" srcset="assets/sponsors/atlas-cloud-dark.svg">
-    <img alt="Atlas Cloud" src="assets/sponsors/atlas-cloud-light.svg" height="40">
-  </picture></a>
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-  <a href="https://threatwatch360.com"><picture>
-    <source media="(prefers-color-scheme: dark)" srcset="assets/sponsors/tw360-dark.svg">
-    <img alt="ThreatWatch360" src="assets/sponsors/tw360-light.svg" height="32">
+    <img alt="Atlas Cloud" src="assets/sponsors/atlas-cloud-light.svg" width="340">
   </picture></a>
 </p>
 
 **[Atlas Cloud](https://www.atlascloud.ai/console/coding-plan)** is a full-modal AI inference platform that gives developers a single AI API to access video generation, image generation, and LLM APIs. Instead of managing multiple vendor integrations, you connect once and get unified access to 300+ curated models across all modalities.
+
+<p align="center">
+  <a href="https://threatwatch360.com"><picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/sponsors/tw360-dark.svg">
+    <img alt="ThreatWatch360" src="assets/sponsors/tw360-light.svg" width="410">
+  </picture></a>
+</p>
 
 **[ThreatWatch360](https://threatwatch360.com)** is an AI-powered offensive-security platform: continuous Attack Surface Management, AI-assisted penetration testing, brand protection, dark-web monitoring, and Cyber Threat Intelligence in one platform. Validated findings with proof-of-concept and business-impact prioritization — signal over alert fatigue.
 


### PR DESCRIPTION
Switches the Sponsors section to the stacked layout (design-handoff Option 1b): each logo big and centered on its own line above its blurb, matching the intended mockup.

- Width-sized for matched cap height: **Atlas `width=340` / ThreatWatch360 `width=410`** (tuned to the repo SVG aspects — the handoff's 430 was calibrated to PNG crops and runs tall here).
- Theme-adaptive `<picture>` kept (light/dark SVG).
- Only the Sponsors block changed; top `SPONSORED BY` strip untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014smQu6HnHQHLZL4u3ExUG5