### PR TITLE
docs(readme): size ThreatWatch360 sponsor logo to width 430

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ The per-class `hunt-*` skills address gap-zero (*"what should I look for in weba
 <p align="center">
   <a href="https://threatwatch360.com"><picture>
     <source media="(prefers-color-scheme: dark)" srcset="assets/sponsors/tw360-dark.svg">
-    <img alt="ThreatWatch360" src="assets/sponsors/tw360-light.svg" width="410">
+    <img alt="ThreatWatch360" src="assets/sponsors/tw360-light.svg" width="430">
   </picture></a>
 </p>
 


### PR DESCRIPTION
Bumps the stacked ThreatWatch360 logo from width 410 to **430** to match the approved sponsor mockup (Atlas 340 / ThreatWatch360 430). Measured bounding boxes confirm the repo SVG aspect matches the design asset, so the designer number applies directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014smQu6HnHQHLZL4u3ExUG5